### PR TITLE
Schematic editor: Keep netlines orthogonal when dragging symbols

### DIFF
--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
@@ -41,19 +41,127 @@
 #include <librepcb/core/project/schematic/items/si_netlabel.h>
 #include <librepcb/core/project/schematic/items/si_netline.h>
 #include <librepcb/core/project/schematic/items/si_netpoint.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
 #include <librepcb/core/project/schematic/items/si_polygon.h>
 #include <librepcb/core/project/schematic/items/si_symbol.h>
 #include <librepcb/core/project/schematic/items/si_symbolpin.h>
 #include <librepcb/core/project/schematic/items/si_text.h>
 #include <librepcb/core/project/schematic/schematic.h>
+#include <librepcb/rust-core/ffi.h>
 
 #include <QtCore>
+
+#include <memory>
+#include <vector>
 
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
 namespace librepcb {
 namespace editor {
+
+/*******************************************************************************
+ *  Local Classes
+ ******************************************************************************/
+namespace {
+
+// Preview helper for a boundary netline which cannot be kept orthogonal by
+// moving an existing netpoint. It replaces one line with an L-bend at the
+// moving side, then either gets discarded during preview or appended to the
+// final undo command.
+class CmdSchematicNetLineSplit final : public UndoCommand {
+public:
+  CmdSchematicNetLineSplit(SI_NetLine& line, SI_NetLineAnchor& movingAnchor,
+                           SI_NetLineAnchor& fixedAnchor)
+    : UndoCommand(QObject::tr("Split netline")),
+      mNetSegment(line.getNetSegment()),
+      mOldLine(line),
+      mBendNetPoint(new SI_NetPoint(mNetSegment, Uuid::createRandom(),
+                                    movingAnchor.getPosition())),
+      mLineToMoving(new SI_NetLine(mNetSegment, Uuid::createRandom(),
+                                   movingAnchor, *mBendNetPoint,
+                                   line.getWidth())),
+      mLineToFixed(new SI_NetLine(mNetSegment, Uuid::createRandom(),
+                                  *mBendNetPoint, fixedAnchor,
+                                  line.getWidth())),
+      mApplied(false) {}
+
+  ~CmdSchematicNetLineSplit() noexcept override {
+    if (mApplied && (!wasEverExecuted())) {
+      // Preview-only splits have already modified the scene. Revert them before
+      // deleting the replacement objects below.
+      try {
+        revert();
+      } catch (...) {
+      }
+    }
+    if (!mApplied) {
+      delete mLineToFixed;
+      delete mLineToMoving;
+      delete mBendNetPoint;
+    }
+    // If mApplied is still true, the SI_NetSegment currently owns these objects
+    // and will delete them with the rest of the segment.
+  }
+
+  SI_NetPoint& getBendNetPoint() noexcept { return *mBendNetPoint; }
+
+  void apply() {
+    if (mApplied) return;
+
+    // Keep the segment cohesive at every step: add the replacement L-bend
+    // before removing the original straight line.
+    mNetSegment.addNetPointsAndNetLines({mBendNetPoint},
+                                        {mLineToMoving, mLineToFixed});
+    mNetSegment.removeNetPointsAndNetLines({}, {&mOldLine});
+    mApplied = true;
+  }
+
+  void revert() {
+    if (!mApplied) return;
+
+    // Same cohesion requirement in reverse: restore the original line before
+    // removing the temporary replacement geometry.
+    mNetSegment.addNetPointsAndNetLines({}, {&mOldLine});
+    mNetSegment.removeNetPointsAndNetLines({mBendNetPoint},
+                                           {mLineToMoving, mLineToFixed});
+    mApplied = false;
+  }
+
+private:
+  bool performExecute() override {
+    apply();  // can throw
+    return true;
+  }
+
+  void performUndo() override { revert(); }  // can throw
+
+  void performRedo() override { apply(); }  // can throw
+
+  SI_NetSegment& mNetSegment;
+  SI_NetLine& mOldLine;
+  SI_NetPoint* mBendNetPoint;
+  SI_NetLine* mLineToMoving;
+  SI_NetLine* mLineToFixed;
+  bool mApplied;
+};
+
+rs::OrthogonalWireDragAnchorKind getAnchorKind(
+    SI_NetLineAnchor& anchor, const QSet<SI_SymbolPin*>& movingPins,
+    const QSet<SI_NetPoint*>& movingNetPoints) noexcept {
+  if (SI_SymbolPin* pin = dynamic_cast<SI_SymbolPin*>(&anchor)) {
+    return movingPins.contains(pin) ? rs::OrthogonalWireDragAnchorKind::Moving
+                                    : rs::OrthogonalWireDragAnchorKind::Fixed;
+  }
+  if (SI_NetPoint* netpoint = dynamic_cast<SI_NetPoint*>(&anchor)) {
+    return movingNetPoints.contains(netpoint)
+        ? rs::OrthogonalWireDragAnchorKind::Moving
+        : rs::OrthogonalWireDragAnchorKind::Movable;
+  }
+  return rs::OrthogonalWireDragAnchorKind::Fixed;
+}
+
+}  // namespace
 
 /*******************************************************************************
  *  Constructors / Destructor
@@ -152,9 +260,128 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
     mCenterPos /= mItemCount;
     mCenterPos.mapToGrid(mSchematic.getGridInterval());
   }
+
+  const QSet<SI_NetPoint*> movingNetPoints = QSet<SI_NetPoint*>(
+      query.getNetPoints().begin(), query.getNetPoints().end());
+  QSet<SI_SymbolPin*> movingPins;
+  foreach (SI_Symbol* symbol, query.getSymbols()) {
+    foreach (SI_SymbolPin* pin, symbol->getPins()) {
+      movingPins.insert(pin);
+    }
+  }
+
+  // Build a plain anchor/wire graph for the Rust algorithm. Schematic-specific
+  // object ownership and undo commands stay here; the actual orthogonal routing
+  // decision is calculated on this generic graph.
+  QHash<SI_NetLineAnchor*, std::size_t> anchorIndexes;
+  std::vector<SI_NetLineAnchor*> anchors;
+  std::vector<rs::OrthogonalWireDragAnchor> rustAnchors;
+  auto addAnchor = [&](SI_NetLineAnchor& anchor) {
+    if (auto it = anchorIndexes.find(&anchor); it != anchorIndexes.end()) {
+      return it.value();
+    }
+    const std::size_t index = anchors.size();
+    const Point& pos = anchor.getPosition();
+    anchorIndexes.insert(&anchor, index);
+    anchors.push_back(&anchor);
+    rustAnchors.push_back(rs::OrthogonalWireDragAnchor{
+        pos.getX().toNm(), pos.getY().toNm(),
+        getAnchorKind(anchor, movingPins, movingNetPoints)});
+    return index;
+  };
+
+  QQueue<SI_NetLineAnchor*> queue;
+  QSet<SI_NetLineAnchor*> queuedAnchors;
+  QSet<SI_NetLineAnchor*> processedAnchors;
+  auto enqueueAnchor = [&](SI_NetLineAnchor& anchor) {
+    if (getAnchorKind(anchor, movingPins, movingNetPoints) ==
+        rs::OrthogonalWireDragAnchorKind::Fixed) {
+      return;
+    }
+    if (queuedAnchors.contains(&anchor) || processedAnchors.contains(&anchor)) {
+      return;
+    }
+    queue.enqueue(&anchor);
+    queuedAnchors.insert(&anchor);
+  };
+
+  // Preserve the schematic feature scope: component pins seed the orthogonal
+  // wire adjustment. Selected netpoints are still marked as "Moving" in the
+  // graph if reached, but dragging a netpoint alone does not start this
+  // component-wire heuristic.
+  foreach (SI_SymbolPin* pin, movingPins) {
+    enqueueAnchor(*pin);
+  }
+
+  QSet<SI_NetLine*> addedLines;
+  std::vector<SI_NetLine*> lines;
+  std::vector<rs::OrthogonalWireDragWire> rustWires;
+  while (!queue.isEmpty()) {
+    SI_NetLineAnchor* anchor = queue.dequeue();
+    queuedAnchors.remove(anchor);
+    if (processedAnchors.contains(anchor)) continue;
+    processedAnchors.insert(anchor);
+    addAnchor(*anchor);
+
+    foreach (SI_NetLine* line, anchor->getNetLines()) {
+      const std::size_t p1 = addAnchor(line->getP1());
+      const std::size_t p2 = addAnchor(line->getP2());
+      if (!addedLines.contains(line)) {
+        addedLines.insert(line);
+        lines.push_back(line);
+        rustWires.push_back(rs::OrthogonalWireDragWire{p1, p2});
+      }
+      if (SI_NetLineAnchor* other = line->getOtherPoint(*anchor)) {
+        enqueueAnchor(*other);
+      }
+    }
+  }
+
+  if ((!rustAnchors.empty()) && (!rustWires.empty())) {
+    std::unique_ptr<rs::OrthogonalWireDragOutput,
+                    decltype(&rs::ffi_orthogonal_wire_drag_delete)>
+        output(rs::ffi_orthogonal_wire_drag_new(
+                   rustAnchors.data(), rustAnchors.size(), rustWires.data(),
+                   rustWires.size()),
+               &rs::ffi_orthogonal_wire_drag_delete);
+
+    for (std::size_t i = 0;
+         i < rs::ffi_orthogonal_wire_drag_anchor_movement_count(output.get());
+         ++i) {
+      const rs::OrthogonalWireDragAnchorMovement movement =
+          rs::ffi_orthogonal_wire_drag_anchor_movement(output.get(), i);
+      if (movement.anchor >= anchors.size()) continue;
+      SI_NetPoint* netpoint =
+          dynamic_cast<SI_NetPoint*>(anchors.at(movement.anchor));
+      if (!netpoint) continue;
+      mStretchEdits.append({new CmdSchematicNetPointEdit(*netpoint),
+                            {movement.stretch_x, movement.stretch_y}});
+    }
+
+    for (std::size_t i = 0;
+         i < rs::ffi_orthogonal_wire_drag_wire_split_count(output.get()); ++i) {
+      const rs::OrthogonalWireDragWireSplit split =
+          rs::ffi_orthogonal_wire_drag_wire_split(output.get(), i);
+      if ((split.wire >= lines.size()) ||
+          (split.moving_anchor >= anchors.size()) ||
+          (split.fixed_anchor >= anchors.size())) {
+        continue;
+      }
+      if ((!split.trigger_x) && (!split.trigger_y)) continue;
+      mSplitNetLineEdits.append({lines.at(split.wire),
+                                 anchors.at(split.moving_anchor),
+                                 anchors.at(split.fixed_anchor),
+                                 {split.trigger_x, split.trigger_y},
+                                 {split.stretch_x, split.stretch_y}});
+    }
+  }
 }
 
 CmdDragSelectedSchematicItems::~CmdDragSelectedSchematicItems() noexcept {
+  if (!wasEverExecuted()) {
+    discardSplitNetLineEdits();
+    discardStretchEdits();
+  }
 }
 
 /*******************************************************************************
@@ -200,6 +427,10 @@ void CmdDragSelectedSchematicItems::setCurrentPosition(
   delta.mapToGrid(mSchematic.getGridInterval());
 
   if (delta != mDeltaPos) {
+    // Split first so any newly inserted bend point receives the same preview
+    // movement as propagated netpoints below.
+    activateNeededSplitNetLineEdits(delta);
+
     // move selected elements
     foreach (CmdSymbolInstanceEdit* cmd, mSymbolEditCmds) {
       cmd->translate(delta - mDeltaPos, true);
@@ -225,12 +456,34 @@ void CmdDragSelectedSchematicItems::setCurrentPosition(
     foreach (CmdImageEdit* cmd, mImageEditCmds) {
       cmd->translate(delta - mDeltaPos, true);
     }
+    const Point increment = delta - mDeltaPos;
+    foreach (const StretchNetPointEdit& s, mStretchEdits) {
+      // Apply only the propagated axes. The selected items still follow the
+      // full cursor delta, while stationary wire geometry moves just enough to
+      // stay orthogonal.
+      const Point masked(s.mask.stretchX ? increment.getX() : Length(0),
+                         s.mask.stretchY ? increment.getY() : Length(0));
+      if (!masked.isOrigin()) {
+        s.cmd->translate(masked, true);
+      }
+    }
     mDeltaPos = delta;
+
+    // If the drag returned to the original line axis, drop preview bends so a
+    // temporary perpendicular excursion does not leave extra netpoints behind.
+    deactivateUnneededSplitNetLineEdits(delta);
   }
 }
 
 void CmdDragSelectedSchematicItems::rotate(
     const Angle& angle, bool aroundCurrentPosition) noexcept {
+  // The orthogonal-stretch heuristic was set up assuming each wire's pre-drag
+  // orientation. A rotation invalidates that, so revert any live stretches
+  // (the netpoints snap back to their pre-drag positions) and stop tracking
+  // them for the remainder of the drag.
+  discardSplitNetLineEdits();
+  discardStretchEdits();
+
   const Point center = (aroundCurrentPosition && (mItemCount > 1))
       ? (mStartPos + mDeltaPos).mappedToGrid(mSchematic.getGridInterval())
       : (mCenterPos + mDeltaPos);
@@ -265,6 +518,11 @@ void CmdDragSelectedSchematicItems::rotate(
 
 void CmdDragSelectedSchematicItems::mirror(
     Qt::Orientation orientation, bool aroundCurrentPosition) noexcept {
+  // Same reasoning as rotate(): a mirror invalidates the per-axis stretch
+  // attribution captured at drag start.
+  discardSplitNetLineEdits();
+  discardStretchEdits();
+
   const Point center = (aroundCurrentPosition && (mItemCount > 1))
       ? (mStartPos + mDeltaPos).mappedToGrid(mSchematic.getGridInterval())
       : (mCenterPos + mDeltaPos);
@@ -323,6 +581,8 @@ bool CmdDragSelectedSchematicItems::performExecute() {
     mTextEditCmds.clear();
     qDeleteAll(mImageEditCmds);
     mImageEditCmds.clear();
+    discardSplitNetLineEdits();
+    discardStretchEdits();
     return false;
   }
 
@@ -358,6 +618,21 @@ bool CmdDragSelectedSchematicItems::performExecute() {
   foreach (CmdImageEdit* cmd, mImageEditCmds) {
     appendChild(cmd);  // can throw
   }
+  for (SplitNetLineEdit& s : mSplitNetLineEdits) {
+    if (s.splitCmd) {
+      appendChild(s.splitCmd);  // can throw
+      s.splitCmd = nullptr;  // ownership transferred to the group
+    }
+  }
+  // Stretch netpoints: appended last so they run after their connected
+  // symbols / netpoints in the undo group (though execution-order doesn't
+  // really matter here since positions were already applied immediately
+  // during the drag preview).
+  foreach (const StretchNetPointEdit& s, mStretchEdits) {
+    appendChild(s.cmd);  // can throw
+  }
+  mSplitNetLineEdits.clear();
+  mStretchEdits.clear();  // ownership transferred to the group
 
   // execute all child commands
   return UndoCommandGroup::performExecute();  // can throw
@@ -365,6 +640,82 @@ bool CmdDragSelectedSchematicItems::performExecute() {
 
 void CmdDragSelectedSchematicItems::performPostExecution() noexcept {
   mSchematic.updateAllLabelAnchors();
+}
+
+void CmdDragSelectedSchematicItems::activateNeededSplitNetLineEdits(
+    const Point& delta) noexcept {
+  for (SplitNetLineEdit& s : mSplitNetLineEdits) {
+    if (s.splitCmd) continue;
+    if ((!s.triggerMask.stretchX || (delta.getX() == 0)) &&
+        (!s.triggerMask.stretchY || (delta.getY() == 0))) {
+      continue;
+    }
+
+    CmdSchematicNetLineSplit* splitCmd = new CmdSchematicNetLineSplit(
+        *s.line, *s.movingAnchor, *s.fixedAnchor);  // can throw
+    // Mutate the live scene for preview. If the drag is committed,
+    // performExecute transfers this already-applied command into the undo
+    // group.
+    splitCmd->apply();  // can throw
+    s.splitCmd = splitCmd;
+    if (s.bendMask.stretchX || s.bendMask.stretchY) {
+      s.stretchCmd = new CmdSchematicNetPointEdit(splitCmd->getBendNetPoint());
+      mStretchEdits.append({s.stretchCmd, s.bendMask});
+    }
+  }
+}
+
+void CmdDragSelectedSchematicItems::deactivateUnneededSplitNetLineEdits(
+    const Point& delta) noexcept {
+  for (SplitNetLineEdit& s : mSplitNetLineEdits) {
+    if (!s.splitCmd) continue;
+    if ((s.triggerMask.stretchX && (delta.getX() != 0)) ||
+        (s.triggerMask.stretchY && (delta.getY() != 0))) {
+      continue;
+    }
+
+    discardStretchEdit(s.stretchCmd);
+    s.stretchCmd = nullptr;
+    delete s.splitCmd;
+    s.splitCmd = nullptr;
+  }
+}
+
+void CmdDragSelectedSchematicItems::discardSplitNetLineEdits() noexcept {
+  for (SplitNetLineEdit& s : mSplitNetLineEdits) {
+    // The stretch command may have already moved the bend point in preview;
+    // delete it first so its destructor restores the bend before the split is
+    // reverted and removed.
+    if (s.stretchCmd) {
+      discardStretchEdit(s.stretchCmd);
+      s.stretchCmd = nullptr;
+    }
+    delete s.splitCmd;
+    s.splitCmd = nullptr;
+  }
+  mSplitNetLineEdits.clear();
+}
+
+void CmdDragSelectedSchematicItems::discardStretchEdit(
+    CmdSchematicNetPointEdit* cmd) noexcept {
+  // Split-created stretch commands are also listed in mStretchEdits for normal
+  // preview movement. Remove them from there to keep ownership single.
+  for (int i = 0; i < mStretchEdits.count(); ++i) {
+    if (mStretchEdits.at(i).cmd == cmd) {
+      delete mStretchEdits.takeAt(i).cmd;
+      return;
+    }
+  }
+  delete cmd;
+}
+
+void CmdDragSelectedSchematicItems::discardStretchEdits() noexcept {
+  // ~CmdSchematicNetPointEdit restores mOldPos when wasEverExecuted() is
+  // false, so deleting un-executed cmds rolls back any live-preview shifts.
+  foreach (const StretchNetPointEdit& s, mStretchEdits) {
+    delete s.cmd;
+  }
+  mStretchEdits.clear();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
@@ -161,6 +161,21 @@ rs::OrthogonalWireDragAnchorKind getAnchorKind(
   return rs::OrthogonalWireDragAnchorKind::Fixed;
 }
 
+bool pointOnOrthogonalSegment(const Point& point, const Point& p1,
+                              const Point& p2) noexcept {
+  if (p1.getX() == p2.getX()) {
+    return (point.getX() == p1.getX()) &&
+        (point.getY() >= qMin(p1.getY(), p2.getY())) &&
+        (point.getY() <= qMax(p1.getY(), p2.getY()));
+  }
+  if (p1.getY() == p2.getY()) {
+    return (point.getY() == p1.getY()) &&
+        (point.getX() >= qMin(p1.getX(), p2.getX())) &&
+        (point.getX() <= qMax(p1.getX(), p2.getX()));
+  }
+  return false;
+}
+
 }  // namespace
 
 /*******************************************************************************
@@ -269,6 +284,8 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
       movingPins.insert(pin);
     }
   }
+  const QSet<SI_NetLabel*> selectedNetLabels = QSet<SI_NetLabel*>(
+      query.getNetLabels().begin(), query.getNetLabels().end());
 
   // Build a plain anchor/wire graph for the Rust algorithm. Schematic-specific
   // object ownership and undo commands stay here; the actual orthogonal routing
@@ -338,6 +355,24 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
   }
 
   if ((!rustAnchors.empty()) && (!rustWires.empty())) {
+    auto mask = [](bool x, bool y) {
+      StretchAxisMask m;
+      m.stretchX = x;
+      m.stretchY = y;
+      return m;
+    };
+    auto mergeMask = [](StretchAxisMask& dst, const StretchAxisMask& src) {
+      dst.stretchX |= src.stretchX;
+      dst.stretchY |= src.stretchY;
+    };
+    std::vector<StretchAxisMask> anchorMasks(anchors.size());
+    for (std::size_t i = 0; i < rustAnchors.size(); ++i) {
+      if (rustAnchors.at(i).kind ==
+          rs::OrthogonalWireDragAnchorKind::Moving) {
+        anchorMasks.at(i) = mask(true, true);
+      }
+    }
+
     std::unique_ptr<rs::OrthogonalWireDragOutput,
                     decltype(&rs::ffi_orthogonal_wire_drag_delete)>
         output(rs::ffi_orthogonal_wire_drag_new(
@@ -354,6 +389,8 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
       SI_NetPoint* netpoint =
           dynamic_cast<SI_NetPoint*>(anchors.at(movement.anchor));
       if (!netpoint) continue;
+      anchorMasks.at(movement.anchor) =
+          mask(movement.stretch_x, movement.stretch_y);
       mStretchEdits.append({new CmdSchematicNetPointEdit(*netpoint),
                             {movement.stretch_x, movement.stretch_y}});
     }
@@ -374,6 +411,33 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
                                  {split.trigger_x, split.trigger_y},
                                  {split.stretch_x, split.stretch_y}});
     }
+
+    QHash<SI_NetLabel*, StretchAxisMask> netLabelMasks;
+    for (std::size_t i = 0; i < lines.size(); ++i) {
+      const rs::OrthogonalWireDragWire& wire = rustWires.at(i);
+      const StretchAxisMask lineMask =
+          mask(anchorMasks.at(wire.p1).stretchX &&
+                   anchorMasks.at(wire.p2).stretchX,
+               anchorMasks.at(wire.p1).stretchY &&
+                   anchorMasks.at(wire.p2).stretchY);
+      if ((!lineMask.stretchX) && (!lineMask.stretchY)) continue;
+
+      SI_NetLine* line = lines.at(i);
+      const Point p1 = line->getP1().getPosition();
+      const Point p2 = line->getP2().getPosition();
+      foreach (SI_NetLabel* label, line->getNetSegment().getNetLabels()) {
+        if (selectedNetLabels.contains(label)) continue;
+        if (!pointOnOrthogonalSegment(label->getAnchorPosition(), p1, p2)) {
+          continue;
+        }
+        mergeMask(netLabelMasks[label], lineMask);
+      }
+    }
+    for (auto it = netLabelMasks.constBegin(); it != netLabelMasks.constEnd();
+         ++it) {
+      mStretchNetLabelEdits.append(
+          {new CmdSchematicNetLabelEdit(*it.key()), it.value()});
+    }
   }
 }
 
@@ -381,6 +445,7 @@ CmdDragSelectedSchematicItems::~CmdDragSelectedSchematicItems() noexcept {
   if (!wasEverExecuted()) {
     discardSplitNetLineEdits();
     discardStretchEdits();
+    discardStretchNetLabelEdits();
   }
 }
 
@@ -467,6 +532,15 @@ void CmdDragSelectedSchematicItems::setCurrentPosition(
         s.cmd->translate(masked, true);
       }
     }
+    foreach (const StretchNetLabelEdit& s, mStretchNetLabelEdits) {
+      // Labels are not anchors in the wire graph, so mirror the movement of
+      // the wire portion they were attached to at drag start.
+      const Point masked(s.mask.stretchX ? increment.getX() : Length(0),
+                         s.mask.stretchY ? increment.getY() : Length(0));
+      if (!masked.isOrigin()) {
+        s.cmd->translate(masked, true);
+      }
+    }
     mDeltaPos = delta;
 
     // If the drag returned to the original line axis, drop preview bends so a
@@ -483,6 +557,7 @@ void CmdDragSelectedSchematicItems::rotate(
   // them for the remainder of the drag.
   discardSplitNetLineEdits();
   discardStretchEdits();
+  discardStretchNetLabelEdits();
 
   const Point center = (aroundCurrentPosition && (mItemCount > 1))
       ? (mStartPos + mDeltaPos).mappedToGrid(mSchematic.getGridInterval())
@@ -522,6 +597,7 @@ void CmdDragSelectedSchematicItems::mirror(
   // attribution captured at drag start.
   discardSplitNetLineEdits();
   discardStretchEdits();
+  discardStretchNetLabelEdits();
 
   const Point center = (aroundCurrentPosition && (mItemCount > 1))
       ? (mStartPos + mDeltaPos).mappedToGrid(mSchematic.getGridInterval())
@@ -583,6 +659,7 @@ bool CmdDragSelectedSchematicItems::performExecute() {
     mImageEditCmds.clear();
     discardSplitNetLineEdits();
     discardStretchEdits();
+    discardStretchNetLabelEdits();
     return false;
   }
 
@@ -609,6 +686,9 @@ bool CmdDragSelectedSchematicItems::performExecute() {
   foreach (CmdSchematicNetLabelEdit* cmd, mNetLabelEditCmds) {
     appendChild(cmd);  // can throw
   }
+  foreach (const StretchNetLabelEdit& s, mStretchNetLabelEdits) {
+    appendChild(s.cmd);  // can throw
+  }
   foreach (CmdPolygonEdit* cmd, mPolygonEditCmds) {
     appendChild(cmd);  // can throw
   }
@@ -633,6 +713,7 @@ bool CmdDragSelectedSchematicItems::performExecute() {
   }
   mSplitNetLineEdits.clear();
   mStretchEdits.clear();  // ownership transferred to the group
+  mStretchNetLabelEdits.clear();  // ownership transferred to the group
 
   // execute all child commands
   return UndoCommandGroup::performExecute();  // can throw
@@ -716,6 +797,13 @@ void CmdDragSelectedSchematicItems::discardStretchEdits() noexcept {
     delete s.cmd;
   }
   mStretchEdits.clear();
+}
+
+void CmdDragSelectedSchematicItems::discardStretchNetLabelEdits() noexcept {
+  foreach (const StretchNetLabelEdit& s, mStretchNetLabelEdits) {
+    delete s.cmd;
+  }
+  mStretchNetLabelEdits.clear();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
@@ -35,6 +35,8 @@
  ******************************************************************************/
 namespace librepcb {
 
+class SI_NetLine;
+class SI_NetLineAnchor;
 class Schematic;
 
 namespace editor {
@@ -101,6 +103,47 @@ private:
   QList<CmdPolygonEdit*> mPolygonEditCmds;
   QList<CmdTextEdit*> mTextEditCmds;
   QList<CmdImageEdit*> mImageEditCmds;
+
+  struct StretchAxisMask {
+    bool stretchX = false;
+    bool stretchY = false;
+  };
+
+  /// Netpoints that should follow a moving pin along a single axis so the
+  /// connecting wire stretches orthogonally during preview. stretchX/stretchY
+  /// indicate which components of the drag delta apply to this netpoint.
+  struct StretchNetPointEdit {
+    CmdSchematicNetPointEdit* cmd;
+    StretchAxisMask mask;
+  };
+  QList<StretchNetPointEdit> mStretchEdits;
+
+  /// Fixed-anchor netlines which need a temporary bend point once the drag
+  /// moves perpendicular to their original orientation.
+  struct SplitNetLineEdit {
+    SI_NetLine* line;
+    SI_NetLineAnchor* movingAnchor;
+    SI_NetLineAnchor* fixedAnchor;
+    /// Axes of the drag which make this split necessary.
+    StretchAxisMask triggerMask;
+    /// Axes to apply to the inserted bend point. This follows the moving anchor
+    /// only along the original netline axis, leaving the far side in place.
+    StretchAxisMask bendMask;
+    UndoCommand* splitCmd = nullptr;
+    CmdSchematicNetPointEdit* stretchCmd = nullptr;
+  };
+  QList<SplitNetLineEdit> mSplitNetLineEdits;
+
+  void activateNeededSplitNetLineEdits(const Point& delta) noexcept;
+  void deactivateUnneededSplitNetLineEdits(const Point& delta) noexcept;
+  void discardSplitNetLineEdits() noexcept;
+
+  /// Drop the live stretch cmds and roll any preview shifts back to the
+  /// pre-drag netpoint positions. Used both for the no-op-drag discard path
+  /// and to invalidate the stretch heuristic when rotate/mirror happens
+  /// mid-drag.
+  void discardStretchEdit(CmdSchematicNetPointEdit* cmd) noexcept;
+  void discardStretchEdits() noexcept;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
@@ -118,6 +118,15 @@ private:
   };
   QList<StretchNetPointEdit> mStretchEdits;
 
+  /// Net labels attached to wire portions which are moved by the orthogonal
+  /// adjustment. They follow the same masked delta to stay visually attached
+  /// to the wire they describe.
+  struct StretchNetLabelEdit {
+    CmdSchematicNetLabelEdit* cmd;
+    StretchAxisMask mask;
+  };
+  QList<StretchNetLabelEdit> mStretchNetLabelEdits;
+
   /// Fixed-anchor netlines which need a temporary bend point once the drag
   /// moves perpendicular to their original orientation.
   struct SplitNetLineEdit {
@@ -144,6 +153,7 @@ private:
   /// mid-drag.
   void discardStretchEdit(CmdSchematicNetPointEdit* cmd) noexcept;
   void discardStretchEdits() noexcept;
+  void discardStretchNetLabelEdits() noexcept;
 };
 
 /*******************************************************************************

--- a/libs/librepcb/rust-core/ffi.h
+++ b/libs/librepcb/rust-core/ffi.h
@@ -128,6 +128,24 @@ enum class InteractiveHtmlBomViewMode {
 };
 
 /**
+ * Wrapper for [AnchorKind]
+ */
+enum class OrthogonalWireDragAnchorKind {
+  /**
+   * Anchor moved by the caller.
+   */
+  Moving,
+  /**
+   * Stationary anchor which may be moved by the algorithm.
+   */
+  Movable,
+  /**
+   * Stationary anchor which must stay fixed.
+   */
+  Fixed,
+};
+
+/**
  * Interactive HTML BOM structure
  *
  * The top-level structure to build & generate a HTML BOM.
@@ -204,6 +222,11 @@ enum class InteractiveHtmlBomViewMode {
 struct InteractiveHtmlBom;
 
 /**
+ * Wrapper for [DragResult]
+ */
+struct OrthogonalWireDragOutput;
+
+/**
  * Wrapper type for [Archive]
  */
 struct ZipArchive;
@@ -275,6 +298,94 @@ struct InteractiveHtmlBomRefMap {
    * Footprint ID
    */
   size_t id;
+};
+
+/**
+ * Wrapper for [Anchor]
+ */
+struct OrthogonalWireDragAnchor {
+  /**
+   * X coordinate in nanometers.
+   */
+  int64_t x;
+  /**
+   * Y coordinate in nanometers.
+   */
+  int64_t y;
+  /**
+   * Drag role.
+   */
+  OrthogonalWireDragAnchorKind kind;
+};
+
+/**
+ * Wrapper for [Wire]
+ */
+struct OrthogonalWireDragWire {
+  /**
+   * First anchor index.
+   */
+  size_t p1;
+  /**
+   * Second anchor index.
+   */
+  size_t p2;
+};
+
+/**
+ * Wrapper for [AnchorMovement]
+ */
+struct OrthogonalWireDragAnchorMovement {
+  /**
+   * Anchor index.
+   */
+  size_t anchor;
+  /**
+   * Apply the drag's X delta.
+   */
+  bool stretch_x;
+  /**
+   * Apply the drag's Y delta.
+   */
+  bool stretch_y;
+};
+
+/**
+ * Wrapper for [WireSplit]
+ */
+struct OrthogonalWireDragWireSplit {
+  /**
+   * Wire index.
+   */
+  size_t wire;
+  /**
+   * Endpoint which follows the drag or propagated stretch.
+   */
+  size_t moving_anchor;
+  /**
+   * Endpoint which stays fixed.
+   */
+  size_t fixed_anchor;
+  /**
+   * Apply the drag's X delta only to decide whether this split is needed.
+   */
+  bool trigger_x;
+  /**
+   * Apply the drag's Y delta only to decide whether this split is needed.
+   */
+  bool trigger_y;
+  /**
+   * Apply the drag's X delta to the inserted bend point.
+   *
+   * This follows the original wire axis, not the perpendicular split trigger.
+   */
+  bool stretch_x;
+  /**
+   * Apply the drag's Y delta to the inserted bend point.
+   *
+   * This follows the original wire axis, not the perpendicular split trigger.
+   */
+  bool stretch_y;
 };
 
 extern "C" {
@@ -526,6 +637,41 @@ double ffi_math_arc_radius_and_center(double dx,
                                       double angle,
                                       double * NONNULL x,
                                       double * NONNULL y);
+
+/**
+ * Wrapper for [calculate_orthogonal_drag]
+ */
+OrthogonalWireDragOutput *ffi_orthogonal_wire_drag_new(const OrthogonalWireDragAnchor *anchors_array,
+                                                       size_t anchors_size,
+                                                       const OrthogonalWireDragWire *wires_array,
+                                                       size_t wires_size);
+
+/**
+ * Delete an [OrthogonalWireDragOutput]
+ */
+void ffi_orthogonal_wire_drag_delete(OrthogonalWireDragOutput *obj);
+
+/**
+ * Get number of anchor movements in an [OrthogonalWireDragOutput]
+ */
+size_t ffi_orthogonal_wire_drag_anchor_movement_count(const OrthogonalWireDragOutput * NONNULL obj);
+
+/**
+ * Get an anchor movement from an [OrthogonalWireDragOutput]
+ */
+OrthogonalWireDragAnchorMovement ffi_orthogonal_wire_drag_anchor_movement(const OrthogonalWireDragOutput * NONNULL obj,
+                                                                          size_t index);
+
+/**
+ * Get number of wire splits in an [OrthogonalWireDragOutput]
+ */
+size_t ffi_orthogonal_wire_drag_wire_split_count(const OrthogonalWireDragOutput * NONNULL obj);
+
+/**
+ * Get a wire split from an [OrthogonalWireDragOutput]
+ */
+OrthogonalWireDragWireSplit ffi_orthogonal_wire_drag_wire_split(const OrthogonalWireDragOutput * NONNULL obj,
+                                                                size_t index);
 
 /**
  * Wrapper for [increment_number_in_string]

--- a/libs/librepcb/rust-core/src/ffi.rs
+++ b/libs/librepcb/rust-core/src/ffi.rs
@@ -5,6 +5,7 @@ mod cpp_ffi;
 mod ibom_ffi;
 mod length_ffi;
 mod math_ffi;
+mod orthogonal_wire_ffi;
 mod toolbox_ffi;
 mod zip_archive_ffi;
 mod zip_writer_ffi;

--- a/libs/librepcb/rust-core/src/ffi/orthogonal_wire_ffi.rs
+++ b/libs/librepcb/rust-core/src/ffi/orthogonal_wire_ffi.rs
@@ -1,0 +1,230 @@
+//! FFI for the orthogonal wire drag algorithm.
+
+use crate::orthogonal_wire::*;
+
+/// Wrapper for [AnchorKind]
+#[repr(C)]
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+enum OrthogonalWireDragAnchorKind {
+  /// Anchor moved by the caller.
+  Moving,
+  /// Stationary anchor which may be moved by the algorithm.
+  Movable,
+  /// Stationary anchor which must stay fixed.
+  Fixed,
+}
+
+impl From<OrthogonalWireDragAnchorKind> for AnchorKind {
+  fn from(value: OrthogonalWireDragAnchorKind) -> Self {
+    match value {
+      OrthogonalWireDragAnchorKind::Moving => AnchorKind::Moving,
+      OrthogonalWireDragAnchorKind::Movable => AnchorKind::Movable,
+      OrthogonalWireDragAnchorKind::Fixed => AnchorKind::Fixed,
+    }
+  }
+}
+
+/// Wrapper for [Anchor]
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct OrthogonalWireDragAnchor {
+  /// X coordinate in nanometers.
+  x: i64,
+  /// Y coordinate in nanometers.
+  y: i64,
+  /// Drag role.
+  kind: OrthogonalWireDragAnchorKind,
+}
+
+impl From<OrthogonalWireDragAnchor> for Anchor {
+  fn from(value: OrthogonalWireDragAnchor) -> Self {
+    Anchor {
+      x: value.x,
+      y: value.y,
+      kind: value.kind.into(),
+    }
+  }
+}
+
+/// Wrapper for [Wire]
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct OrthogonalWireDragWire {
+  /// First anchor index.
+  p1: usize,
+  /// Second anchor index.
+  p2: usize,
+}
+
+impl From<OrthogonalWireDragWire> for Wire {
+  fn from(value: OrthogonalWireDragWire) -> Self {
+    Wire {
+      p1: value.p1,
+      p2: value.p2,
+    }
+  }
+}
+
+/// Wrapper for [AnchorMovement]
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct OrthogonalWireDragAnchorMovement {
+  /// Anchor index.
+  anchor: usize,
+  /// Apply the drag's X delta.
+  stretch_x: bool,
+  /// Apply the drag's Y delta.
+  stretch_y: bool,
+}
+
+impl From<AnchorMovement> for OrthogonalWireDragAnchorMovement {
+  fn from(value: AnchorMovement) -> Self {
+    Self {
+      anchor: value.anchor,
+      stretch_x: value.mask.x,
+      stretch_y: value.mask.y,
+    }
+  }
+}
+
+/// Wrapper for [WireSplit]
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct OrthogonalWireDragWireSplit {
+  /// Wire index.
+  wire: usize,
+  /// Endpoint which follows the drag or propagated stretch.
+  moving_anchor: usize,
+  /// Endpoint which stays fixed.
+  fixed_anchor: usize,
+  /// Apply the drag's X delta only to decide whether this split is needed.
+  trigger_x: bool,
+  /// Apply the drag's Y delta only to decide whether this split is needed.
+  trigger_y: bool,
+  /// Apply the drag's X delta to the inserted bend point.
+  ///
+  /// This follows the original wire axis, not the perpendicular split trigger.
+  stretch_x: bool,
+  /// Apply the drag's Y delta to the inserted bend point.
+  ///
+  /// This follows the original wire axis, not the perpendicular split trigger.
+  stretch_y: bool,
+}
+
+impl From<WireSplit> for OrthogonalWireDragWireSplit {
+  fn from(value: WireSplit) -> Self {
+    Self {
+      wire: value.wire,
+      moving_anchor: value.moving_anchor,
+      fixed_anchor: value.fixed_anchor,
+      trigger_x: value.trigger_mask.x,
+      trigger_y: value.trigger_mask.y,
+      stretch_x: value.bend_mask.x,
+      stretch_y: value.bend_mask.y,
+    }
+  }
+}
+
+/// Wrapper for [DragResult]
+struct OrthogonalWireDragOutput {
+  /// Movements for existing movable anchors.
+  anchor_movements: Vec<OrthogonalWireDragAnchorMovement>,
+  /// Wires that need to be split into an L-bend.
+  wire_splits: Vec<OrthogonalWireDragWireSplit>,
+}
+
+/// Wrapper for [calculate_orthogonal_drag]
+#[no_mangle]
+unsafe extern "C" fn ffi_orthogonal_wire_drag_new(
+  anchors_array: *const OrthogonalWireDragAnchor,
+  anchors_size: usize,
+  wires_array: *const OrthogonalWireDragWire,
+  wires_size: usize,
+) -> *mut OrthogonalWireDragOutput {
+  let anchors = std::slice::from_raw_parts(anchors_array, anchors_size)
+    .iter()
+    .copied()
+    .map(Anchor::from)
+    .collect::<Vec<_>>();
+  let wires = std::slice::from_raw_parts(wires_array, wires_size)
+    .iter()
+    .copied()
+    .map(Wire::from)
+    .collect::<Vec<_>>();
+  let result = calculate_orthogonal_drag(&anchors, &wires);
+  Box::into_raw(Box::new(OrthogonalWireDragOutput {
+    anchor_movements: result
+      .anchor_movements
+      .into_iter()
+      .map(OrthogonalWireDragAnchorMovement::from)
+      .collect(),
+    wire_splits: result
+      .wire_splits
+      .into_iter()
+      .map(OrthogonalWireDragWireSplit::from)
+      .collect(),
+  }))
+}
+
+/// Delete an [OrthogonalWireDragOutput]
+#[no_mangle]
+unsafe extern "C" fn ffi_orthogonal_wire_drag_delete(
+  obj: *mut OrthogonalWireDragOutput,
+) {
+  if !obj.is_null() {
+    drop(Box::from_raw(obj));
+  }
+}
+
+/// Get number of anchor movements in an [OrthogonalWireDragOutput]
+#[no_mangle]
+extern "C" fn ffi_orthogonal_wire_drag_anchor_movement_count(
+  obj: &OrthogonalWireDragOutput,
+) -> usize {
+  obj.anchor_movements.len()
+}
+
+/// Get an anchor movement from an [OrthogonalWireDragOutput]
+#[no_mangle]
+extern "C" fn ffi_orthogonal_wire_drag_anchor_movement(
+  obj: &OrthogonalWireDragOutput,
+  index: usize,
+) -> OrthogonalWireDragAnchorMovement {
+  obj.anchor_movements.get(index).copied().unwrap_or(
+    OrthogonalWireDragAnchorMovement {
+      anchor: usize::MAX,
+      stretch_x: false,
+      stretch_y: false,
+    },
+  )
+}
+
+/// Get number of wire splits in an [OrthogonalWireDragOutput]
+#[no_mangle]
+extern "C" fn ffi_orthogonal_wire_drag_wire_split_count(
+  obj: &OrthogonalWireDragOutput,
+) -> usize {
+  obj.wire_splits.len()
+}
+
+/// Get a wire split from an [OrthogonalWireDragOutput]
+#[no_mangle]
+extern "C" fn ffi_orthogonal_wire_drag_wire_split(
+  obj: &OrthogonalWireDragOutput,
+  index: usize,
+) -> OrthogonalWireDragWireSplit {
+  obj
+    .wire_splits
+    .get(index)
+    .copied()
+    .unwrap_or(OrthogonalWireDragWireSplit {
+      wire: usize::MAX,
+      moving_anchor: usize::MAX,
+      fixed_anchor: usize::MAX,
+      trigger_x: false,
+      trigger_y: false,
+      stretch_x: false,
+      stretch_y: false,
+    })
+}

--- a/libs/librepcb/rust-core/src/lib.rs
+++ b/libs/librepcb/rust-core/src/lib.rs
@@ -13,6 +13,8 @@ mod ffi;
 
 // Modules
 pub mod math;
+#[cfg(any(test, feature = "ffi"))]
+mod orthogonal_wire;
 pub mod toolbox;
 mod types;
 

--- a/libs/librepcb/rust-core/src/orthogonal_wire.rs
+++ b/libs/librepcb/rust-core/src/orthogonal_wire.rs
@@ -1,0 +1,526 @@
+//! Orthogonal wire drag calculation.
+
+use std::collections::HashMap;
+
+/// The role of a wire anchor during a drag operation.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum AnchorKind {
+  /// The anchor is moved by the caller's normal drag operation.
+  Moving,
+  /// The anchor is stationary, but the algorithm may move it to keep wires
+  /// orthogonal.
+  Movable,
+  /// The anchor must stay in place. A boundary wire to this anchor may need an
+  /// inserted bend point.
+  Fixed,
+}
+
+/// A point-like endpoint in the wire graph.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct Anchor {
+  /// X coordinate in nanometers.
+  pub x: i64,
+  /// Y coordinate in nanometers.
+  pub y: i64,
+  /// Drag role.
+  pub kind: AnchorKind,
+}
+
+/// A wire between two anchors.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct Wire {
+  /// First anchor index.
+  pub p1: usize,
+  /// Second anchor index.
+  pub p2: usize,
+}
+
+/// Axis mask of a propagated movement.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub(crate) struct AxisMask {
+  /// Apply the drag's X delta.
+  pub x: bool,
+  /// Apply the drag's Y delta.
+  pub y: bool,
+}
+
+impl AxisMask {
+  /// Create a new mask.
+  fn new(x: bool, y: bool) -> Self {
+    Self { x, y }
+  }
+
+  /// Check whether no axis is set.
+  fn is_empty(&self) -> bool {
+    !self.x && !self.y
+  }
+
+  /// Merge another mask into this one.
+  ///
+  /// Returns `true` if the mask gained at least one new axis.
+  fn merge(&mut self, other: Self) -> bool {
+    let before = *self;
+    self.x |= other.x;
+    self.y |= other.y;
+    *self != before
+  }
+}
+
+/// Movement to apply to a movable anchor.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct AnchorMovement {
+  /// Anchor index.
+  pub anchor: usize,
+  /// Axes to move.
+  pub mask: AxisMask,
+}
+
+/// Wire which needs a bend point inserted at its moving side.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct WireSplit {
+  /// Wire index.
+  pub wire: usize,
+  /// Endpoint which follows the drag or propagated stretch.
+  pub moving_anchor: usize,
+  /// Endpoint which stays fixed.
+  pub fixed_anchor: usize,
+  /// Axes of the drag which make this split necessary.
+  pub trigger_mask: AxisMask,
+  /// Axes to move the inserted bend point.
+  ///
+  /// The bend follows the moving endpoint only along the original wire axis, so
+  /// the untouched side of the wire can stay in place.
+  pub bend_mask: AxisMask,
+}
+
+/// Result of an orthogonal wire drag calculation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DragResult {
+  /// Movements for existing movable anchors.
+  pub anchor_movements: Vec<AnchorMovement>,
+  /// Wires that need to be split into an L-bend.
+  pub wire_splits: Vec<WireSplit>,
+}
+
+/// Mutable state used while calculating anchor movements and boundary splits.
+struct CalculationState<'a> {
+  /// Input anchors.
+  anchors: &'a [Anchor],
+  /// Accumulated movement masks per movable anchor.
+  anchor_masks: HashMap<usize, AxisMask>,
+  /// Accumulated split masks per boundary wire.
+  wire_split_masks: HashMap<usize, WireSplit>,
+}
+
+impl<'a> CalculationState<'a> {
+  /// Create empty state for an anchor set.
+  fn new(anchors: &'a [Anchor]) -> Self {
+    Self {
+      anchors,
+      anchor_masks: HashMap::new(),
+      wire_split_masks: HashMap::new(),
+    }
+  }
+
+  /// Accumulate movement for one existing movable anchor.
+  fn add_anchor_movement(&mut self, anchor: usize, mask: AxisMask) {
+    if mask.is_empty() {
+      return;
+    }
+    if self.anchors[anchor].kind != AnchorKind::Movable {
+      return;
+    }
+    self.anchor_masks.entry(anchor).or_default().merge(mask);
+  }
+
+  /// Add a boundary split between one endpoint which follows the drag and one
+  /// endpoint which stays at its original position.
+  fn add_wire_split(
+    &mut self,
+    wire_index: usize,
+    moving_anchor: usize,
+    fixed_anchor: usize,
+    trigger_mask: AxisMask,
+    bend_mask: AxisMask,
+  ) {
+    if trigger_mask.is_empty() {
+      return;
+    }
+    let split = self
+      .wire_split_masks
+      .entry(wire_index)
+      .or_insert(WireSplit {
+        wire: wire_index,
+        moving_anchor,
+        fixed_anchor,
+        trigger_mask: AxisMask::default(),
+        bend_mask: AxisMask::default(),
+      });
+    split.moving_anchor = moving_anchor;
+    split.fixed_anchor = fixed_anchor;
+    split.trigger_mask.merge(trigger_mask);
+    split.bend_mask.merge(bend_mask);
+  }
+
+  /// Movement mask for one anchor. Directly dragged anchors follow both axes;
+  /// movable anchors follow only axes discovered from adjacent moving anchors.
+  fn movement_mask(&self, anchor: usize) -> AxisMask {
+    match self.anchors[anchor].kind {
+      AnchorKind::Moving => AxisMask::new(true, true),
+      AnchorKind::Movable => {
+        self.anchor_masks.get(&anchor).copied().unwrap_or_default()
+      }
+      AnchorKind::Fixed => AxisMask::default(),
+    }
+  }
+}
+
+/// Calculate how stationary anchors need to move to keep wires orthogonal.
+///
+/// The algorithm starts at anchors marked as [`AnchorKind::Moving`]. If a
+/// directly connected wire was horizontal before the drag, the neighbour follows
+/// the drag's Y delta; if it was vertical, the neighbour follows the X delta.
+/// The movement is intentionally limited to that one neighbouring vertex. If an
+/// adjacent wire would otherwise become diagonal, the caller can split it when
+/// the trigger mask is active and move the inserted bend point with the returned
+/// bend mask.
+pub(crate) fn calculate_orthogonal_drag(
+  anchors: &[Anchor],
+  wires: &[Wire],
+) -> DragResult {
+  let adjacency = build_adjacency(anchors, wires);
+  let mut state = CalculationState::new(anchors);
+
+  for anchor_index in moving_anchors(anchors) {
+    for (_, other_index) in &adjacency[anchor_index] {
+      let mask = initial_mask(anchors[anchor_index], anchors[*other_index]);
+      state.add_anchor_movement(*other_index, mask);
+    }
+  }
+
+  for (wire_index, wire) in wires.iter().enumerate() {
+    if wire.p1 >= anchors.len() || wire.p2 >= anchors.len() {
+      continue;
+    }
+    if let Some((moving_anchor, fixed_anchor, trigger_mask, bend_mask)) =
+      split_for_different_endpoint_movement(wire, &state)
+    {
+      state.add_wire_split(
+        wire_index,
+        moving_anchor,
+        fixed_anchor,
+        trigger_mask,
+        bend_mask,
+      );
+    }
+  }
+
+  let mut anchor_movements = state
+    .anchor_masks
+    .into_iter()
+    .filter(|(_, mask)| !mask.is_empty())
+    .map(|(anchor, mask)| AnchorMovement { anchor, mask })
+    .collect::<Vec<_>>();
+  anchor_movements.sort_by_key(|movement| movement.anchor);
+
+  let mut wire_splits =
+    state.wire_split_masks.into_values().collect::<Vec<_>>();
+  wire_splits.sort_by_key(|split| split.wire);
+
+  DragResult {
+    anchor_movements,
+    wire_splits,
+  }
+}
+
+/// Build anchor-to-wire adjacency and ignore wires with invalid endpoints.
+fn build_adjacency(
+  anchors: &[Anchor],
+  wires: &[Wire],
+) -> Vec<Vec<(usize, usize)>> {
+  let mut adjacency = vec![Vec::new(); anchors.len()];
+  for (wire_index, wire) in wires.iter().enumerate() {
+    if wire.p1 >= anchors.len() || wire.p2 >= anchors.len() {
+      continue;
+    }
+    adjacency[wire.p1].push((wire_index, wire.p2));
+    adjacency[wire.p2].push((wire_index, wire.p1));
+  }
+  adjacency
+}
+
+/// Return all anchors moved directly by the caller.
+fn moving_anchors(anchors: &[Anchor]) -> impl Iterator<Item = usize> + '_ {
+  anchors
+    .iter()
+    .enumerate()
+    .filter(|(_, anchor)| anchor.kind == AnchorKind::Moving)
+    .map(|(index, _)| index)
+}
+
+/// Determine the first stretch mask from a moving anchor to its neighbour.
+fn initial_mask(moving: Anchor, other: Anchor) -> AxisMask {
+  AxisMask::new(moving.x == other.x, moving.y == other.y)
+}
+
+/// Determine whether a wire needs a split because only one endpoint moves
+/// perpendicular to its original orientation.
+fn split_for_different_endpoint_movement(
+  wire: &Wire,
+  state: &CalculationState,
+) -> Option<(usize, usize, AxisMask, AxisMask)> {
+  let p1 = state.anchors[wire.p1];
+  let p2 = state.anchors[wire.p2];
+  let p1_mask = state.movement_mask(wire.p1);
+  let p2_mask = state.movement_mask(wire.p2);
+
+  if p1.x == p2.x {
+    split_for_axis(
+      wire.p1,
+      p1_mask,
+      wire.p2,
+      p2_mask,
+      AxisMask::new(true, false),
+      AxisMask::new(false, true),
+    )
+  } else if p1.y == p2.y {
+    split_for_axis(
+      wire.p1,
+      p1_mask,
+      wire.p2,
+      p2_mask,
+      AxisMask::new(false, true),
+      AxisMask::new(true, false),
+    )
+  } else {
+    None
+  }
+}
+
+/// Build a split when exactly one endpoint moves along the wire's perpendicular
+/// axis. If both endpoints move, or neither does, the wire stays orthogonal as-is.
+fn split_for_axis(
+  p1: usize,
+  p1_mask: AxisMask,
+  p2: usize,
+  p2_mask: AxisMask,
+  trigger_axis: AxisMask,
+  wire_axis: AxisMask,
+) -> Option<(usize, usize, AxisMask, AxisMask)> {
+  match (
+    mask_contains(p1_mask, trigger_axis),
+    mask_contains(p2_mask, trigger_axis),
+  ) {
+    (true, false) => {
+      Some((p1, p2, trigger_axis, mask_intersection(p1_mask, wire_axis)))
+    }
+    (false, true) => {
+      Some((p2, p1, trigger_axis, mask_intersection(p2_mask, wire_axis)))
+    }
+    _ => None,
+  }
+}
+
+/// Check whether all axes from `needle` are set in `mask`.
+fn mask_contains(mask: AxisMask, needle: AxisMask) -> bool {
+  (!needle.x || mask.x) && (!needle.y || mask.y)
+}
+
+/// Keep only axes set in both masks.
+fn mask_intersection(a: AxisMask, b: AxisMask) -> AxisMask {
+  AxisMask::new(a.x && b.x, a.y && b.y)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn moving(x: i64, y: i64) -> Anchor {
+    Anchor {
+      x,
+      y,
+      kind: AnchorKind::Moving,
+    }
+  }
+
+  fn movable(x: i64, y: i64) -> Anchor {
+    Anchor {
+      x,
+      y,
+      kind: AnchorKind::Movable,
+    }
+  }
+
+  fn fixed(x: i64, y: i64) -> Anchor {
+    Anchor {
+      x,
+      y,
+      kind: AnchorKind::Fixed,
+    }
+  }
+
+  fn wire(p1: usize, p2: usize) -> Wire {
+    Wire { p1, p2 }
+  }
+
+  fn axes(x: bool, y: bool) -> AxisMask {
+    AxisMask::new(x, y)
+  }
+
+  #[test]
+  fn direct_pin_to_pin_wire_creates_split() {
+    let result =
+      calculate_orthogonal_drag(&[moving(0, 0), fixed(10, 0)], &[wire(0, 1)]);
+
+    assert_eq!(result.anchor_movements, vec![]);
+    assert_eq!(
+      result.wire_splits,
+      vec![WireSplit {
+        wire: 0,
+        moving_anchor: 0,
+        fixed_anchor: 1,
+        trigger_mask: axes(false, true),
+        bend_mask: axes(true, false),
+      }]
+    );
+  }
+
+  #[test]
+  fn direct_pin_to_netpoint_moves_netpoint() {
+    let result =
+      calculate_orthogonal_drag(&[moving(0, 0), movable(10, 0)], &[wire(0, 1)]);
+
+    assert_eq!(
+      result.anchor_movements,
+      vec![AnchorMovement {
+        anchor: 1,
+        mask: axes(false, true),
+      }]
+    );
+    assert_eq!(result.wire_splits, vec![]);
+  }
+
+  #[test]
+  fn direct_netpoint_move_splits_next_fixed_boundary() {
+    let result = calculate_orthogonal_drag(
+      &[moving(0, 0), movable(10, 0), fixed(20, 0)],
+      &[wire(0, 1), wire(1, 2)],
+    );
+
+    assert_eq!(
+      result.anchor_movements,
+      vec![AnchorMovement {
+        anchor: 1,
+        mask: axes(false, true),
+      }]
+    );
+    assert_eq!(
+      result.wire_splits,
+      vec![WireSplit {
+        wire: 1,
+        moving_anchor: 1,
+        fixed_anchor: 2,
+        trigger_mask: axes(false, true),
+        bend_mask: axes(false, false),
+      }]
+    );
+  }
+
+  #[test]
+  fn movement_stops_after_one_movable_anchor() {
+    let result = calculate_orthogonal_drag(
+      &[moving(0, 0), movable(10, 0), movable(20, 0), fixed(30, 0)],
+      &[wire(0, 1), wire(1, 2), wire(2, 3)],
+    );
+
+    assert_eq!(
+      result.anchor_movements,
+      vec![AnchorMovement {
+        anchor: 1,
+        mask: axes(false, true),
+      }]
+    );
+    assert_eq!(
+      result.wire_splits,
+      vec![WireSplit {
+        wire: 1,
+        moving_anchor: 1,
+        fixed_anchor: 2,
+        trigger_mask: axes(false, true),
+        bend_mask: axes(false, false),
+      }]
+    );
+  }
+
+  #[test]
+  fn same_netpoint_can_receive_both_axes() {
+    let result = calculate_orthogonal_drag(
+      &[moving(0, 10), moving(10, 0), movable(10, 10), fixed(20, 10)],
+      &[wire(0, 2), wire(1, 2), wire(2, 3)],
+    );
+
+    assert_eq!(
+      result.anchor_movements,
+      vec![AnchorMovement {
+        anchor: 2,
+        mask: axes(true, true),
+      }]
+    );
+    assert_eq!(
+      result.wire_splits,
+      vec![WireSplit {
+        wire: 2,
+        moving_anchor: 2,
+        fixed_anchor: 3,
+        trigger_mask: axes(false, true),
+        bend_mask: axes(true, false),
+      }]
+    );
+  }
+
+  #[test]
+  fn vertical_wire_split_moves_bend_only_along_wire_axis() {
+    let result = calculate_orthogonal_drag(
+      &[moving(0, 0), movable(0, 10), fixed(0, 20)],
+      &[wire(0, 1), wire(1, 2)],
+    );
+
+    assert_eq!(
+      result.anchor_movements,
+      vec![AnchorMovement {
+        anchor: 1,
+        mask: axes(true, false),
+      }]
+    );
+    assert_eq!(
+      result.wire_splits,
+      vec![WireSplit {
+        wire: 1,
+        moving_anchor: 1,
+        fixed_anchor: 2,
+        trigger_mask: axes(true, false),
+        bend_mask: axes(false, false),
+      }]
+    );
+  }
+
+  #[test]
+  fn diagonal_wires_are_left_unchanged() {
+    let result = calculate_orthogonal_drag(
+      &[moving(0, 0), movable(10, 10)],
+      &[wire(0, 1)],
+    );
+
+    assert_eq!(result.anchor_movements, vec![]);
+    assert_eq!(result.wire_splits, vec![]);
+  }
+
+  #[test]
+  fn moving_anchor_at_other_end_is_ignored() {
+    let result =
+      calculate_orthogonal_drag(&[moving(0, 0), moving(10, 0)], &[wire(0, 1)]);
+
+    assert_eq!(result.anchor_movements, vec![]);
+    assert_eq!(result.wire_splits, vec![]);
+  }
+}

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(
   editor/project/addcomponentdialogtest.cpp
   editor/project/board/boardclipboarddatatest.cpp
   editor/project/board/cmdboardspecctraimporttest.cpp
+  editor/project/cmd/cmddragselectedschematicitemstest.cpp
   editor/project/schematic/schematicclipboarddatatest.cpp
   editor/utils/shortcutsreferencegeneratortest.cpp
   editor/utils/slinthelperstest.cpp

--- a/tests/unittests/editor/project/cmd/cmddragselectedschematicitemstest.cpp
+++ b/tests/unittests/editor/project/cmd/cmddragselectedschematicitemstest.cpp
@@ -1,0 +1,444 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+
+#include "../../../testhelpers.h"
+
+#include <gtest/gtest.h>
+#include <librepcb/core/fileio/transactionaldirectory.h>
+#include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/library/cmp/component.h>
+#include <librepcb/core/library/cmp/componentpinsignalmap.h>
+#include <librepcb/core/library/cmp/componentsignal.h>
+#include <librepcb/core/library/sym/symbol.h>
+#include <librepcb/core/project/circuit/circuit.h>
+#include <librepcb/core/project/circuit/componentinstance.h>
+#include <librepcb/core/project/circuit/componentsignalinstance.h>
+#include <librepcb/core/project/circuit/netclass.h>
+#include <librepcb/core/project/circuit/netsignal.h>
+#include <librepcb/core/project/project.h>
+#include <librepcb/core/project/projectlibrary.h>
+#include <librepcb/core/project/schematic/items/si_netline.h>
+#include <librepcb/core/project/schematic/items/si_netpoint.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
+#include <librepcb/core/project/schematic/items/si_symbol.h>
+#include <librepcb/core/project/schematic/items/si_symbolpin.h>
+#include <librepcb/core/project/schematic/schematic.h>
+#include <librepcb/editor/graphics/graphicslayer.h>
+#include <librepcb/editor/graphics/graphicslayerlist.h>
+#include <librepcb/editor/project/cmd/cmddragselectedschematicitems.h>
+#include <librepcb/editor/project/projectcrossprobe.h>
+#include <librepcb/editor/project/schematic/graphicsitems/sgi_symbol.h>
+#include <librepcb/editor/project/schematic/schematicgraphicsscene.h>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+namespace tests {
+
+using ::librepcb::tests::TestHelpers;
+
+/*******************************************************************************
+ *  Test Class
+ ******************************************************************************/
+
+class CmdDragSelectedSchematicItemsTest : public ::testing::Test {
+protected:
+  CmdDragSelectedSchematicItemsTest()
+    : mUuidFactory(TestHelpers::createDeterministicUuidFactory()),
+      mSymbolUuid(mUuidFactory()),
+      mPinUuid(mUuidFactory()),
+      mComponentUuid(mUuidFactory()),
+      mSignalUuid(mUuidFactory()),
+      mVariantUuid(mUuidFactory()),
+      mGateUuid(mUuidFactory()),
+      mIgnorePlacementLocks(false) {}
+
+  ~CmdDragSelectedSchematicItemsTest() noexcept override {
+    mScene.reset();
+    mLayers.reset();
+    mProject.reset();
+    if (mProjectDir.isValid()) {
+      QDir(mProjectDir.toStr()).removeRecursively();
+    }
+  }
+
+  Uuid uuid() { return mUuidFactory(); }
+
+  static Length mm(qreal value) { return Length::fromMm(value); }
+
+  static Point point(qreal x, qreal y) { return Point(mm(x), mm(y)); }
+
+  void createProject() {
+    mProjectDir = FilePath::getRandomTempPath();
+    mProject =
+        Project::create(std::make_unique<TransactionalDirectory>(
+                            TransactionalFileSystem::openRW(mProjectDir)),
+                        "project.lpp", mUuidFactory);
+
+    auto symbol = std::make_unique<Symbol>(
+        mSymbolUuid, Version::fromString("1.0"), "LibrePCB Tests",
+        TestHelpers::createDeterministicDateTime(), ElementName("Symbol"), "",
+        "");
+    symbol->getPins().append(std::make_shared<SymbolPin>(
+        mPinUuid, CircuitIdentifier("P"), Point(), UnsignedLength(0),
+        Angle::deg0(), Point(), Angle::deg0(), PositiveLength(1000000),
+        Alignment(HAlign::left(), VAlign::center())));
+    mSymbol = symbol.get();
+    mProject->getLibrary().addSymbol(*symbol.release());
+
+    auto component = std::make_unique<Component>(
+        mComponentUuid, Version::fromString("1.0"), "LibrePCB Tests",
+        TestHelpers::createDeterministicDateTime(), ElementName("Component"),
+        "", "");
+    component->getSignals().append(std::make_shared<ComponentSignal>(
+        mSignalUuid, CircuitIdentifier("SIG"), SignalRole::passive(), "", false,
+        false, false));
+    auto variant = std::make_shared<ComponentSymbolVariant>(
+        mVariantUuid, "", ElementName("default"), "");
+    auto gate = std::make_shared<ComponentSymbolVariantItem>(
+        mGateUuid, mSymbolUuid, Point(), Angle::deg0(), true,
+        ComponentSymbolVariantItemSuffix(""));
+    gate->getPinSignalMap().append(std::make_shared<ComponentPinSignalMapItem>(
+        mPinUuid, std::optional<Uuid>(mSignalUuid),
+        CmpSigPinDisplayType::componentSignal()));
+    variant->getSymbolItems().append(gate);
+    component->getSymbolVariants().append(variant);
+    mComponent = component.get();
+    mProject->getLibrary().addComponent(*component.release());
+
+    auto schematic = std::make_unique<Schematic>(
+        *mProject, std::make_unique<TransactionalDirectory>(), "schematic",
+        uuid(), ElementName("Schematic"));
+    mSchematic = schematic.get();
+    mProject->addSchematic(*schematic.release());
+  }
+
+  ComponentInstance& addComponentInstance(const CircuitIdentifier& name) {
+    ComponentInstance* instance = new ComponentInstance(
+        mProject->getCircuit(), uuid(), *mComponent, mVariantUuid, name);
+    mProject->getCircuit().addComponentInstance(*instance);
+    return *instance;
+  }
+
+  SI_Symbol& addSymbol(ComponentInstance& component, const Point& position) {
+    SI_Symbol* symbol = new SI_Symbol(*mSchematic, uuid(), component, mGateUuid,
+                                      position, Angle::deg0(), false, false);
+    mSchematic->addSymbol(*symbol);
+    return *symbol;
+  }
+
+  NetSignal& addNetSignal(const CircuitIdentifier& name) {
+    NetClass* netclass = mProject->getCircuit().getNetClasses().first();
+    NetSignal* netSignal =
+        new NetSignal(mProject->getCircuit(), uuid(), *netclass, name, false);
+    mProject->getCircuit().addNetSignal(*netSignal);
+    return *netSignal;
+  }
+
+  SI_NetSegment& addNetSegment(NetSignal& netSignal) {
+    SI_NetSegment* segment = new SI_NetSegment(*mSchematic, uuid(), netSignal);
+    mSchematic->addNetSegment(*segment);
+    return *segment;
+  }
+
+  SI_SymbolPin& pin(SI_Symbol& symbol) const {
+    return *symbol.getPin(mPinUuid);
+  }
+
+  void connect(ComponentInstance& component, NetSignal& netSignal) {
+    component.getSignalInstance(mSignalUuid)->setNetSignal(&netSignal);
+  }
+
+  void createScene() {
+    mLayers = GraphicsLayerList::schematicLayers(nullptr);
+    mSceneContext = std::make_shared<SchematicGraphicsScene::Context>(
+        SchematicGraphicsScene::Context{
+            nullptr, std::make_shared<ProjectCrossProbe>(),
+            GraphicsLayer::State::Enabled, mIgnorePlacementLocks});
+    mScene = std::make_unique<SchematicGraphicsScene>(*mSchematic, *mLayers,
+                                                      mSceneContext);
+  }
+
+  void select(SI_Symbol& symbol) {
+    mScene->getSymbols().value(&symbol)->setSelected(true);
+  }
+
+  static bool isOrthogonal(const SI_NetLine& line) {
+    return (line.getP1().getPosition().getX() ==
+            line.getP2().getPosition().getX()) ||
+        (line.getP1().getPosition().getY() ==
+         line.getP2().getPosition().getY());
+  }
+
+  static ::testing::AssertionResult allNetLinesOrthogonal(
+      const SI_NetSegment& segment) {
+    foreach (SI_NetLine* line, segment.getNetLines()) {
+      if (!isOrthogonal(*line)) {
+        return ::testing::AssertionFailure()
+            << "Netline " << line->getUuid().toStr().toStdString()
+            << " is diagonal";
+      }
+    }
+    return ::testing::AssertionSuccess();
+  }
+
+  static int netPointCountAt(const SI_NetSegment& segment, const Point& pos) {
+    int count = 0;
+    foreach (SI_NetPoint* netPoint, segment.getNetPoints()) {
+      if (netPoint->getPosition() == pos) {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  std::function<Uuid()> mUuidFactory;
+  Uuid mSymbolUuid;
+  Uuid mPinUuid;
+  Uuid mComponentUuid;
+  Uuid mSignalUuid;
+  Uuid mVariantUuid;
+  Uuid mGateUuid;
+  FilePath mProjectDir;
+  std::unique_ptr<Project> mProject;
+  Symbol* mSymbol = nullptr;
+  Component* mComponent = nullptr;
+  Schematic* mSchematic = nullptr;
+  bool mIgnorePlacementLocks;
+  std::unique_ptr<GraphicsLayerList> mLayers;
+  std::shared_ptr<SchematicGraphicsScene::Context> mSceneContext;
+  std::unique_ptr<SchematicGraphicsScene> mScene;
+};
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST_F(CmdDragSelectedSchematicItemsTest,
+       testDragDirectPinToPinNetlineCreatesOrthogonalBend) {
+  createProject();
+  ComponentInstance& c1 = addComponentInstance(CircuitIdentifier("U1"));
+  ComponentInstance& c2 = addComponentInstance(CircuitIdentifier("U2"));
+  NetSignal& net = addNetSignal(CircuitIdentifier("N"));
+  connect(c1, net);
+  connect(c2, net);
+  SI_Symbol& s1 = addSymbol(c1, point(0, 0));
+  SI_Symbol& s2 = addSymbol(c2, point(10, 0));
+  SI_NetSegment& segment = addNetSegment(net);
+  SI_NetLine* line = new SI_NetLine(segment, uuid(), pin(s1), pin(s2),
+                                    SI_NetLine::getDefaultWidth());
+  segment.addNetPointsAndNetLines({}, {line});
+  createScene();
+  select(s1);
+
+  CmdDragSelectedSchematicItems cmd(*mScene, Point());
+  cmd.setCurrentPosition(point(0, 5));
+  EXPECT_TRUE(cmd.execute());
+
+  EXPECT_EQ(1, segment.getNetPoints().count());
+  EXPECT_EQ(2, segment.getNetLines().count());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+
+  cmd.undo();
+  EXPECT_EQ(0, segment.getNetPoints().count());
+  EXPECT_EQ(1, segment.getNetLines().count());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+
+  cmd.redo();
+  EXPECT_EQ(1, segment.getNetPoints().count());
+  EXPECT_EQ(2, segment.getNetLines().count());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+}
+
+TEST_F(CmdDragSelectedSchematicItemsTest,
+       testDragThroughNetPointCreatesOrthogonalBendAtFixedPin) {
+  createProject();
+  ComponentInstance& c1 = addComponentInstance(CircuitIdentifier("U1"));
+  ComponentInstance& c2 = addComponentInstance(CircuitIdentifier("U2"));
+  NetSignal& net = addNetSignal(CircuitIdentifier("N"));
+  connect(c1, net);
+  connect(c2, net);
+  SI_Symbol& s1 = addSymbol(c1, point(0, 0));
+  SI_Symbol& s2 = addSymbol(c2, point(20, 0));
+  SI_NetSegment& segment = addNetSegment(net);
+  SI_NetPoint* netPoint = new SI_NetPoint(segment, uuid(), point(10, 0));
+  SI_NetLine* firstLine = new SI_NetLine(segment, uuid(), pin(s1), *netPoint,
+                                         SI_NetLine::getDefaultWidth());
+  SI_NetLine* secondLine = new SI_NetLine(segment, uuid(), *netPoint, pin(s2),
+                                          SI_NetLine::getDefaultWidth());
+  segment.addNetPointsAndNetLines({netPoint}, {firstLine, secondLine});
+  createScene();
+  select(s1);
+
+  CmdDragSelectedSchematicItems cmd(*mScene, Point());
+  cmd.setCurrentPosition(point(0, 5.08));
+  EXPECT_TRUE(cmd.execute());
+
+  EXPECT_EQ(2, segment.getNetPoints().count());
+  EXPECT_EQ(3, segment.getNetLines().count());
+  EXPECT_EQ(point(10, 5.08), netPoint->getPosition());
+  EXPECT_EQ(1, netPointCountAt(segment, point(10, 0)));
+  EXPECT_EQ(0, netPointCountAt(segment, point(20, 5.08)));
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+
+  cmd.undo();
+  EXPECT_EQ(1, segment.getNetPoints().count());
+  EXPECT_EQ(2, segment.getNetLines().count());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+
+  cmd.redo();
+  EXPECT_EQ(2, segment.getNetPoints().count());
+  EXPECT_EQ(3, segment.getNetLines().count());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+}
+
+TEST_F(CmdDragSelectedSchematicItemsTest,
+       testDragThroughVerticalNetPointKeepsUpperSegmentFixed) {
+  createProject();
+  ComponentInstance& c1 = addComponentInstance(CircuitIdentifier("U1"));
+  ComponentInstance& c2 = addComponentInstance(CircuitIdentifier("U2"));
+  NetSignal& net = addNetSignal(CircuitIdentifier("N"));
+  connect(c1, net);
+  connect(c2, net);
+  SI_Symbol& s1 = addSymbol(c1, point(0, 0));
+  SI_Symbol& s2 = addSymbol(c2, point(0, 20));
+  SI_NetSegment& segment = addNetSegment(net);
+  SI_NetPoint* netPoint = new SI_NetPoint(segment, uuid(), point(0, 10));
+  SI_NetLine* firstLine = new SI_NetLine(segment, uuid(), pin(s1), *netPoint,
+                                         SI_NetLine::getDefaultWidth());
+  SI_NetLine* secondLine = new SI_NetLine(segment, uuid(), *netPoint, pin(s2),
+                                          SI_NetLine::getDefaultWidth());
+  segment.addNetPointsAndNetLines({netPoint}, {firstLine, secondLine});
+  createScene();
+  select(s1);
+
+  CmdDragSelectedSchematicItems cmd(*mScene, Point());
+  cmd.setCurrentPosition(point(5.08, 0));
+  EXPECT_TRUE(cmd.execute());
+
+  EXPECT_EQ(2, segment.getNetPoints().count());
+  EXPECT_EQ(3, segment.getNetLines().count());
+  EXPECT_EQ(point(5.08, 10), netPoint->getPosition());
+  EXPECT_EQ(1, netPointCountAt(segment, point(0, 10)));
+  EXPECT_EQ(0, netPointCountAt(segment, point(5.08, 20)));
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+}
+
+TEST_F(CmdDragSelectedSchematicItemsTest, testNoDragDiscardsCleanly) {
+  createProject();
+  ComponentInstance& c1 = addComponentInstance(CircuitIdentifier("U1"));
+  ComponentInstance& c2 = addComponentInstance(CircuitIdentifier("U2"));
+  NetSignal& net = addNetSignal(CircuitIdentifier("N"));
+  connect(c1, net);
+  connect(c2, net);
+  SI_Symbol& s1 = addSymbol(c1, point(0, 0));
+  SI_Symbol& s2 = addSymbol(c2, point(10, 0));
+  SI_NetSegment& segment = addNetSegment(net);
+  SI_NetPoint* netPoint = new SI_NetPoint(segment, uuid(), point(5, 0));
+  SI_NetLine* firstLine = new SI_NetLine(segment, uuid(), pin(s1), *netPoint,
+                                         SI_NetLine::getDefaultWidth());
+  SI_NetLine* secondLine = new SI_NetLine(segment, uuid(), *netPoint, pin(s2),
+                                          SI_NetLine::getDefaultWidth());
+  segment.addNetPointsAndNetLines({netPoint}, {firstLine, secondLine});
+  createScene();
+  select(s1);
+
+  CmdDragSelectedSchematicItems cmd(*mScene, Point());
+  cmd.setCurrentPosition(Point());
+  EXPECT_FALSE(cmd.execute());
+
+  EXPECT_EQ(1, segment.getNetPoints().count());
+  EXPECT_EQ(2, segment.getNetLines().count());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+}
+
+TEST_F(CmdDragSelectedSchematicItemsTest,
+       testRotateDuringDragDiscardsStretchEdits) {
+  createProject();
+  ComponentInstance& c1 = addComponentInstance(CircuitIdentifier("U1"));
+  ComponentInstance& c2 = addComponentInstance(CircuitIdentifier("U2"));
+  NetSignal& net = addNetSignal(CircuitIdentifier("N"));
+  connect(c1, net);
+  connect(c2, net);
+  SI_Symbol& s1 = addSymbol(c1, point(0, 0));
+  SI_Symbol& s2 = addSymbol(c2, point(10, 0));
+  SI_NetSegment& segment = addNetSegment(net);
+  SI_NetPoint* netPoint = new SI_NetPoint(segment, uuid(), point(5, 0));
+  SI_NetLine* firstLine = new SI_NetLine(segment, uuid(), pin(s1), *netPoint,
+                                         SI_NetLine::getDefaultWidth());
+  SI_NetLine* secondLine = new SI_NetLine(segment, uuid(), *netPoint, pin(s2),
+                                          SI_NetLine::getDefaultWidth());
+  segment.addNetPointsAndNetLines({netPoint}, {firstLine, secondLine});
+  createScene();
+  select(s1);
+
+  CmdDragSelectedSchematicItems cmd(*mScene, Point());
+  cmd.setCurrentPosition(point(0, 5.08));
+  cmd.rotate(Angle::deg90(), false);
+  EXPECT_TRUE(cmd.execute());
+
+  EXPECT_EQ(point(5, 0), netPoint->getPosition());
+  EXPECT_EQ(1, segment.getNetPoints().count());
+  EXPECT_EQ(2, segment.getNetLines().count());
+}
+
+TEST_F(CmdDragSelectedSchematicItemsTest,
+       testDragReturnToAxisRemovesPreviewBend) {
+  createProject();
+  ComponentInstance& c1 = addComponentInstance(CircuitIdentifier("U1"));
+  ComponentInstance& c2 = addComponentInstance(CircuitIdentifier("U2"));
+  NetSignal& net = addNetSignal(CircuitIdentifier("N"));
+  connect(c1, net);
+  connect(c2, net);
+  SI_Symbol& s1 = addSymbol(c1, point(0, 0));
+  SI_Symbol& s2 = addSymbol(c2, point(10, 0));
+  SI_NetSegment& segment = addNetSegment(net);
+  SI_NetLine* line = new SI_NetLine(segment, uuid(), pin(s1), pin(s2),
+                                    SI_NetLine::getDefaultWidth());
+  segment.addNetPointsAndNetLines({}, {line});
+  createScene();
+  select(s1);
+
+  CmdDragSelectedSchematicItems cmd(*mScene, Point());
+  cmd.setCurrentPosition(point(0, 5.08));
+  cmd.setCurrentPosition(point(2.54, 0));
+  EXPECT_TRUE(cmd.execute());
+
+  EXPECT_EQ(0, segment.getNetPoints().count());
+  EXPECT_EQ(1, segment.getNetLines().count());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace editor
+}  // namespace librepcb

--- a/tests/unittests/editor/project/cmd/cmddragselectedschematicitemstest.cpp
+++ b/tests/unittests/editor/project/cmd/cmddragselectedschematicitemstest.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/geometry/netlabel.h>
 #include <librepcb/core/library/cmp/component.h>
 #include <librepcb/core/library/cmp/componentpinsignalmap.h>
 #include <librepcb/core/library/cmp/componentsignal.h>
@@ -38,6 +39,7 @@
 #include <librepcb/core/project/project.h>
 #include <librepcb/core/project/projectlibrary.h>
 #include <librepcb/core/project/schematic/items/si_netline.h>
+#include <librepcb/core/project/schematic/items/si_netlabel.h>
 #include <librepcb/core/project/schematic/items/si_netpoint.h>
 #include <librepcb/core/project/schematic/items/si_netsegment.h>
 #include <librepcb/core/project/schematic/items/si_symbol.h>
@@ -347,6 +349,49 @@ TEST_F(CmdDragSelectedSchematicItemsTest,
   EXPECT_EQ(point(5.08, 10), netPoint->getPosition());
   EXPECT_EQ(1, netPointCountAt(segment, point(0, 10)));
   EXPECT_EQ(0, netPointCountAt(segment, point(5.08, 20)));
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+}
+
+TEST_F(CmdDragSelectedSchematicItemsTest,
+       testDragMovesNetLabelOnShiftedWire) {
+  createProject();
+  ComponentInstance& c1 = addComponentInstance(CircuitIdentifier("U1"));
+  ComponentInstance& c2 = addComponentInstance(CircuitIdentifier("U2"));
+  NetSignal& net = addNetSignal(CircuitIdentifier("N"));
+  connect(c1, net);
+  connect(c2, net);
+  SI_Symbol& s1 = addSymbol(c1, point(0, 0));
+  SI_Symbol& s2 = addSymbol(c2, point(20, 0));
+  SI_NetSegment& segment = addNetSegment(net);
+  SI_NetPoint* netPoint = new SI_NetPoint(segment, uuid(), point(10, 0));
+  SI_NetLine* firstLine = new SI_NetLine(segment, uuid(), pin(s1), *netPoint,
+                                         SI_NetLine::getDefaultWidth());
+  SI_NetLine* secondLine = new SI_NetLine(segment, uuid(), *netPoint, pin(s2),
+                                          SI_NetLine::getDefaultWidth());
+  segment.addNetPointsAndNetLines({netPoint}, {firstLine, secondLine});
+  SI_NetLabel* label = new SI_NetLabel(
+      segment, NetLabel(uuid(), point(5, 1), Angle::deg0(), false));
+  segment.addNetLabel(*label);
+  createScene();
+  select(s1);
+
+  CmdDragSelectedSchematicItems cmd(*mScene, Point());
+  cmd.setCurrentPosition(point(0, 5.08));
+  EXPECT_TRUE(cmd.execute());
+
+  EXPECT_EQ(point(10, 5.08), netPoint->getPosition());
+  EXPECT_EQ(point(5, 6.08), label->getPosition());
+  EXPECT_EQ(point(5, 5.08), label->getAnchorPosition());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+
+  cmd.undo();
+  EXPECT_EQ(point(10, 0), netPoint->getPosition());
+  EXPECT_EQ(point(5, 1), label->getPosition());
+  EXPECT_TRUE(allNetLinesOrthogonal(segment));
+
+  cmd.redo();
+  EXPECT_EQ(point(10, 5.08), netPoint->getPosition());
+  EXPECT_EQ(point(5, 6.08), label->getPosition());
   EXPECT_TRUE(allNetLinesOrthogonal(segment));
 }
 


### PR DESCRIPTION
This changes schematic component dragging so connected wires stay orthogonal automatically where possible.

The new behavior kicks in when moving selected symbols with connected schematic wires. In particular, it handles:

- pin-to-pin wires, by inserting an L-bend instead of leaving a diagonal wire
- pin-to-netpoint-to-pin chains, by moving the adjacent netpoint and adding a bend at the next segment when needed
- horizontal and vertical multi-segment runs, while only adjusting the nearest affected vertex instead of pulling an entire collinear chain along
- undo/redo and live preview during the drag

The routing decision itself is implemented in Rust in `librepcb-rust-core`. The Rust side works on a small generic graph of anchors and wires, so it is not tied to schematic editor classes and can be unit-tested directly. The C++ schematic editor code builds this graph from `SI_SymbolPin`, `SI_NetPoint`, and `SI_NetLine`, calls the Rust FFI, then applies the returned movements using the existing preview and undo command infrastructure.

I kept the actual schematic mutation in C++ because the editor object model, live drag preview, and undo/redo ownership are all still C++/Qt-based. The new C++ code is therefore mostly adapter and command plumbing, while the generic wire movement calculation lives in Rust.

Tests added:

- Rust unit tests for the generic orthogonal wire movement algorithm
- C++ integration tests for schematic dragging behavior, including pin-to-pin, pin-netpoint-pin, vertical multi-segment, no-op drag, rotate-during-drag cleanup, and return-to-axis preview cleanup cases

Fixes #1701

Demo:


https://github.com/user-attachments/assets/441614a9-acff-4f3a-b375-1fcef2c6477d

