### PR TITLE
UI: Let description text fields grow for long texts

### DIFF
--- a/libs/librepcb/ui/library/cat/categorytab.slint
+++ b/libs/librepcb/ui/library/cat/categorytab.slint
@@ -67,7 +67,8 @@ component CategoryTab inherits Tab {
             description-txt := DescriptionRowHeader { }
 
             description-edt := TextEdit {
-                height: 100px;
+                min-height: 65px;  // Corresponds to 3 text rows
+                max-height: 250px;  // Allow growing up to this height for long texts
                 text: tabs[index].description;
                 read-only: read-only;
                 accessible-label: description-txt.text;

--- a/libs/librepcb/ui/library/cmp/componenttab.slint
+++ b/libs/librepcb/ui/library/cmp/componenttab.slint
@@ -88,7 +88,8 @@ component ComponentMetadataTab inherits GridLayout {
         description-txt := DescriptionRowHeader { }
 
         description-edt := TextEdit {
-            height: 100px;
+            min-height: 65px;  // Corresponds to 3 text rows
+            max-height: 250px;  // Allow growing up to this height for long texts
             text: tabs[index].description;
             read-only: read-only;
             accessible-label: description-txt.text;

--- a/libs/librepcb/ui/library/dev/devicetab.slint
+++ b/libs/librepcb/ui/library/dev/devicetab.slint
@@ -149,7 +149,8 @@ component DeviceMetadataTab inherits GridLayout {
         description-txt := DescriptionRowHeader { }
 
         description-edt := TextEdit {
-            height: 100px;
+            min-height: 65px;  // Corresponds to 3 text rows
+            max-height: 250px;  // Allow growing up to this height for long texts
             text: tabs[index].description;
             read-only: read-only;
             accessible-label: description-txt.text;

--- a/libs/librepcb/ui/library/lib/librarytab.slint
+++ b/libs/librepcb/ui/library/lib/librarytab.slint
@@ -122,7 +122,8 @@ component LibraryMetadataTab inherits GridLayout {
         description-txt := DescriptionRowHeader { }
 
         description-edt := TextEdit {
-            height: 100px;
+            min-height: 65px;  // Corresponds to 3 text rows
+            max-height: 250px;  // Allow growing up to this height for long texts
             text: tabs[index].description;
             read-only: read-only;
             accessible-label: description-txt.text;

--- a/libs/librepcb/ui/library/org/organizationtab.slint
+++ b/libs/librepcb/ui/library/org/organizationtab.slint
@@ -95,7 +95,8 @@ export component OrganizationTab inherits Tab {
                 description-txt := DescriptionRowHeader { }
 
                 description-edt := TextEdit {
-                    height: 100px;
+                    min-height: 65px;  // Corresponds to 3 text rows
+                    max-height: 250px;  // Allow growing up to this height for long texts
                     text: tabs[index].description;
                     read-only: read-only;
                     accessible-label: description-txt.text;

--- a/libs/librepcb/ui/library/pkg/packagetab.slint
+++ b/libs/librepcb/ui/library/pkg/packagetab.slint
@@ -103,7 +103,8 @@ component PackageMetadataTab inherits GridLayout {
         description-txt := DescriptionRowHeader { }
 
         description-edt := TextEdit {
-            height: 100px;
+            min-height: 65px;  // Corresponds to 3 text rows
+            max-height: 250px;  // Allow growing up to this height for long texts
             text: tabs[index].description;
             read-only: read-only;
             accessible-label: description-txt.text;

--- a/libs/librepcb/ui/library/sym/symboltab.slint
+++ b/libs/librepcb/ui/library/sym/symboltab.slint
@@ -90,7 +90,8 @@ component SymbolMetadataTab {
             description-txt := DescriptionRowHeader { }
 
             description-edt := TextEdit {
-                height: 100px;
+                min-height: 65px;  // Corresponds to 3 text rows
+                max-height: 250px;  // Allow growing up to this height for long texts
                 text: tabs[index].description;
                 read-only: read-only;
                 accessible-label: description-txt.text;


### PR DESCRIPTION
In all library editor tabs, let the description text field grow in height up to 250px, if there is enough vertical space available. This allows to read long descriptions without scrolling. In addition, if there is not enough vertical space available, let the text fields shrink down to 65px height.