### PR TITLE
Improve macOS keyboard shortcuts look-and-feel and input fallbacks

### DIFF
--- a/libs/librepcb/editor/editorcommand.cpp
+++ b/libs/librepcb/editor/editorcommand.cpp
@@ -60,6 +60,53 @@ EditorCommand::~EditorCommand() noexcept {
 }
 
 /*******************************************************************************
+ *  Static Methods
+ ******************************************************************************/
+
+QList<QKeySequence> EditorCommand::getShortcutsWithMacFallbacks(
+    const QList<QKeySequence>& sequences) noexcept {
+#if defined(Q_OS_MACOS)
+  QList<QKeySequence> result = sequences;
+  for (const QKeySequence& seq : sequences) {
+    if (seq.isEmpty()) continue;
+    if (seq.count() == 1) {
+      QKeyCombination comb = seq[0];
+      Qt::KeyboardModifiers modifiers = comb.keyboardModifiers();
+      Qt::Key key = comb.key();
+
+      // Fallback 1: If it has Command (Qt::ControlModifier), add a fallback with Control (Qt::MetaModifier)
+      if (modifiers.testFlag(Qt::ControlModifier)) {
+        Qt::KeyboardModifiers fallbackModifiers = (modifiers & ~Qt::ControlModifier) | Qt::MetaModifier;
+        QKeySequence fallback(QKeyCombination(fallbackModifiers, key));
+        if (!result.contains(fallback)) {
+          result.append(fallback);
+        }
+
+        // If it also has Qt::Key_Delete, add a fallback for that too
+        if (key == Qt::Key_Delete) {
+          QKeySequence fallback2(QKeyCombination(fallbackModifiers, Qt::Key_Backspace));
+          if (!result.contains(fallback2)) {
+            result.append(fallback2);
+          }
+        }
+      }
+
+      // Fallback 2: If it has Qt::Key_Delete, add a fallback with Qt::Key_Backspace
+      if (key == Qt::Key_Delete) {
+        QKeySequence fallback(QKeyCombination(modifiers, Qt::Key_Backspace));
+        if (!result.contains(fallback)) {
+          result.append(fallback);
+        }
+      }
+    }
+  }
+  return result;
+#else
+  return sequences;
+#endif
+}
+
+/*******************************************************************************
  *  Setters
  ******************************************************************************/
 
@@ -125,7 +172,7 @@ QAction* EditorCommand::setupAction(QAction* action,
     action->setMenuRole(QAction::QuitRole);
   }
   if (!flags.testFlag(ActionFlag::NoShortcuts)) {
-    action->setShortcuts(mKeySequences);
+    action->setShortcuts(getShortcutsWithMacFallbacks(mKeySequences));
     if (flags.testFlag(ActionFlag::WidgetShortcut)) {
       action->setShortcutContext(Qt::WidgetShortcut);
     } else if (flags.testFlag(ActionFlag::ApplicationShortcut)) {
@@ -137,8 +184,9 @@ QAction* EditorCommand::setupAction(QAction* action,
     }
     action->installEventFilter(const_cast<EditorCommand*>(this));
     connect(this, &EditorCommand::shortcutsChanged, action,
-            static_cast<void (QAction::*)(const QList<QKeySequence>&)>(
-                &QAction::setShortcuts));
+            [action](const QList<QKeySequence>& seqs) {
+              action->setShortcuts(getShortcutsWithMacFallbacks(seqs));
+            });
   }
   return action;
 }

--- a/libs/librepcb/editor/editorcommand.h
+++ b/libs/librepcb/editor/editorcommand.h
@@ -88,6 +88,10 @@ public:
     return mKeySequences;
   }
 
+  // Static Methods
+  static QList<QKeySequence> getShortcutsWithMacFallbacks(
+      const QList<QKeySequence>& sequences) noexcept;
+
   // Setters
   void setKeySequences(const QList<QKeySequence>& sequences) noexcept;
 

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -537,8 +537,8 @@ void PackageEditorState_DrawPolygonBase::updateOverlayText() noexcept {
 void PackageEditorState_DrawPolygonBase::updateStatusBarMessage() noexcept {
   QString note = " " %
       tr("(press %1 to disable snap, %2 to abort)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift") % "/" %
-               QCoreApplication::translate("QShortcut", "Ctrl"))
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier) % "/" %
+               EditorToolbox::modifierKeyText(Qt::ControlModifier))
           .arg(tr("right click"));
 
   if (mMode == Mode::RECT) {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
@@ -25,6 +25,7 @@
 #include "../../../cmd/cmdzoneedit.h"
 #include "../../../graphics/zonegraphicsitem.h"
 #include "../../../undostack.h"
+#include "../../../utils/editortoolbox.h"
 #include "../footprintgraphicsitem.h"
 
 #include <librepcb/core/library/pkg/footprint.h>
@@ -359,7 +360,7 @@ void PackageEditorState_DrawZone::updateOverlayText() noexcept {
 void PackageEditorState_DrawZone::updateStatusBarMessage() noexcept {
   QString note = " " %
       tr("(press %1 to disable snap, %2 to abort)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift"),
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier),
                tr("right click"));
 
   if (!mIsUndoCmdActive) {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.cpp
@@ -24,6 +24,7 @@
 
 #include "../../../undocommandgroup.h"
 #include "../../../undostack.h"
+#include "../../../utils/editortoolbox.h"
 #include "../../cmd/cmdfootprintpadedit.h"
 #include "../footprintgraphicsitem.h"
 #include "../footprintpadgraphicsitem.h"
@@ -74,8 +75,8 @@ bool PackageEditorState_ReNumberPads::entry() noexcept {
   const QString note = " " %
       tr("(press %1 for single-selection, %2 to change numbering mode, %3 to "
          "finish)")
-          .arg(QCoreApplication::translate("QShortcut", "Ctrl"),
-               QCoreApplication::translate("QShortcut", "Shift"),
+          .arg(EditorToolbox::modifierKeyText(Qt::ControlModifier),
+               EditorToolbox::modifierKeyText(Qt::ShiftModifier),
                QCoreApplication::translate("QShortcut", "Return"));
   mAdapter.fsmSetStatusBarMessage(tr("Click on the next pad") % note);
   mAdapter.fsmSetViewCursor(Qt::PointingHandCursor);

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -526,8 +526,8 @@ void SymbolEditorState_DrawPolygonBase::updateOverlayText() noexcept {
 void SymbolEditorState_DrawPolygonBase::updateStatusBarMessage() noexcept {
   QString note = " " %
       tr("(press %1 to disable snap, %2 to abort)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift") % "/" %
-               QCoreApplication::translate("QShortcut", "Ctrl"))
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier) % "/" %
+               EditorToolbox::modifierKeyText(Qt::ControlModifier))
           .arg(tr("right click"));
 
   if (mMode == Mode::RECT) {

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.cpp
@@ -24,6 +24,7 @@
 
 #include "../../../editorcommandset.h"
 #include "../../../undostack.h"
+#include "../../../utils/editortoolbox.h"
 #include "../../cmd/cmdchangenetsignalofschematicnetsegment.h"
 #include "../../cmd/cmdcombineschematicnetsegments.h"
 #include "../../cmd/cmdcompsiginstsetnetsignal.h"
@@ -851,8 +852,8 @@ std::optional<NetSignal*>
   menu.setDefaultAction(
       menu.addAction(QIcon(":/img/actions/draw_wire.png"),
                      tr("Add New Bus Member") +
-                         QString(" (%1)").arg(QCoreApplication::translate(
-                             "QShortcut", "Ctrl"))));
+                         QString(" (%1)").arg(
+                             EditorToolbox::modifierKeyText(Qt::ControlModifier))));
   NetSignal* selectedNet = nullptr;
   for (NetSignal* net : std::as_const(nets)) {
     QAction* a =

--- a/libs/librepcb/editor/utils/editortoolbox.cpp
+++ b/libs/librepcb/editor/utils/editortoolbox.cpp
@@ -152,6 +152,39 @@ bool EditorToolbox::isSystemThemeDark() noexcept {
   return value;
 }
 
+QString EditorToolbox::modifierKeyText(Qt::KeyboardModifier modifier) noexcept {
+#if defined(Q_OS_MACOS)
+  // Use the native symbols which macOS users are familiar with. Note that on
+  // macOS Qt::ControlModifier corresponds to the Command key (not the physical
+  // Control key), which is exactly the key triggering the action.
+  switch (modifier) {
+    case Qt::ControlModifier:
+      return QStringLiteral("⌘");  // ⌘ Command (Place of Interest Sign)
+    case Qt::ShiftModifier:
+      return QStringLiteral("⇧");  // ⇧ Shift (Upwards White Arrow)
+    case Qt::AltModifier:
+      return QStringLiteral("⌥");  // ⌥ Option
+    case Qt::MetaModifier:
+      return QStringLiteral("⌃");  // ⌃ Control (Up Arrowhead)
+    default:
+      break;
+  }
+#endif
+  switch (modifier) {
+    case Qt::ControlModifier:
+      return QCoreApplication::translate("QShortcut", "Ctrl");
+    case Qt::ShiftModifier:
+      return QCoreApplication::translate("QShortcut", "Shift");
+    case Qt::AltModifier:
+      return QCoreApplication::translate("QShortcut", "Alt");
+    case Qt::MetaModifier:
+      return QCoreApplication::translate("QShortcut", "Meta");
+    default:
+      qWarning() << "Unhandled modifier in EditorToolbox::modifierKeyText().";
+      return QString();
+  }
+}
+
 QString EditorToolbox::toSingleLine(const QString& s) noexcept {
   return QString(s).replace("\n", "\\n");
 }

--- a/libs/librepcb/editor/utils/editortoolbox.h
+++ b/libs/librepcb/editor/utils/editortoolbox.h
@@ -80,6 +80,22 @@ public:
   static bool isSystemThemeDark() noexcept;
 
   /**
+   * @brief Get the platform-specific display text for a keyboard modifier
+   *
+   * Intended for messages which refer to a modifier key (e.g. "press Ctrl to
+   * ..."). On macOS, the corresponding symbol (e.g. "⌘" for Control) is
+   * returned to match the native look & feel and the key which is actually
+   * used (the Command key is mapped to Qt::ControlModifier on macOS, while
+   * the physical Control key does not trigger the action). On other platforms,
+   * the textual name (e.g. "Ctrl") is returned.
+   *
+   * @param modifier  The keyboard modifier (e.g. Qt::ControlModifier).
+   *
+   * @return The display text for the given modifier.
+   */
+  static QString modifierKeyText(Qt::KeyboardModifier modifier) noexcept;
+
+  /**
    * @brief Escape newlines to convert a multi-line to a single-line string
    *
    * @param s     Input string.

--- a/libs/librepcb/editor/utils/measuretool.cpp
+++ b/libs/librepcb/editor/utils/measuretool.cpp
@@ -417,7 +417,7 @@ void MeasureTool::updateStatusBarMessage() noexcept {
       EditorCommandSet::instance().remove.getKeySequences();
   const QString disableSnapNote = " " %
       tr("(press %1 to disable snap)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift"));
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier));
 
   if (mEndPos && (!copyKeys.isEmpty()) && (!deleteKeys.isEmpty())) {
     emit statusBarMessageChanged(

--- a/libs/librepcb/editor/utils/uihelpers.cpp
+++ b/libs/librepcb/editor/utils/uihelpers.cpp
@@ -310,7 +310,9 @@ ui::EditorCommand l2s(const EditorCommand& cmd, ui::EditorCommand in) noexcept {
   in.status_tip = q2s(cmd.getDescription());
   const QKeySequence shortcut = cmd.getKeySequences().value(0);
   if (shortcut.count() == 1) {
-    in.shortcut = q2s(shortcut.toString());
+    // Use the native text so that on macOS the modifier symbols (e.g. "⌘"
+    // instead of "Ctrl") are shown, matching the actually used keys.
+    in.shortcut = q2s(shortcut.toString(QKeySequence::NativeText));
     in.modifiers = q2s(shortcut[0].keyboardModifiers());
     in.key = q2s(shortcut[0].key());
     if (in.modifiers.shift && (in.key.size() == 1) &&

--- a/libs/librepcb/editor/utils/uihelpers.cpp
+++ b/libs/librepcb/editor/utils/uihelpers.cpp
@@ -367,7 +367,8 @@ bool isShortcut(const slint::private_api::KeyEvent& e,
 
   // Find the command with the corresponding keyboard shortcut.
   if (const EditorCommand* c = map.value(cmd.id)) {
-    for (const QKeySequence& seq : c->getKeySequences()) {
+    for (const QKeySequence& seq :
+         EditorCommand::getShortcutsWithMacFallbacks(c->getKeySequences())) {
       if (isKeySequence(e, seq)) {
         return true;
       }

--- a/libs/librepcb/ui/mainmenubar.slint
+++ b/libs/librepcb/ui/mainmenubar.slint
@@ -434,7 +434,7 @@ export component MainMenuBar {
                     text: @tr("Cut");
                     icon: @image-url("../../font-awesome/svgs/solid/scissors.svg");
                     status-tip: @tr("Cut the selected object(s) to clipboard");
-                    shortcuts: "Ctrl+X";
+                    shortcuts: Cmd.clipboard-cut.shortcut;
                     enabled: Data.current-tab.features.cut == FeatureState.enabled;
 
                     clicked => {
@@ -447,7 +447,7 @@ export component MainMenuBar {
                     text: @tr("Copy");
                     icon: @image-url("../../font-awesome/svgs/regular/copy.svg");
                     status-tip: @tr("Copy the selected object(s) to clipboard");
-                    shortcuts: "Ctrl+C";
+                    shortcuts: Cmd.clipboard-copy.shortcut;
                     enabled: Data.current-tab.features.copy == FeatureState.enabled;
 
                     clicked => {
@@ -460,7 +460,7 @@ export component MainMenuBar {
                     text: @tr("Paste");
                     icon: @image-url("../../font-awesome/svgs/solid/paste.svg");
                     status-tip: @tr("Paste object(s) from the clipboard");
-                    shortcuts: "Ctrl+V";
+                    shortcuts: Cmd.clipboard-paste.shortcut;
                     enabled: Data.current-tab.features.paste == FeatureState.enabled;
 
                     clicked => {


### PR DESCRIPTION
This PR addresses the macOS keyboard shortcut and tooltip feedback from #1817. It improves the native look-and-feel on macOS and ensures that shortcuts work seamlessly with common Mac keyboard layouts.

### Key Changes
* **Show Native macOS Symbols in UI (#1817 Item 1, Part 1)**:
  * Updated tooltips, menus, and status messages to display native symbols (⌘, ⇧, ⌥, ⌃) instead of text labels like "Ctrl" on macOS.
  * Added `EditorToolbox::modifierKeyText()` to handle bare modifier keys in info box and status bar hints.

<img width="289" height="677" alt="image" src="https://github.com/user-attachments/assets/bc500a4e-3c16-4cdf-b150-9be1d06a2776" />

Note that macOS typically doesn't use `+` for key combinations.

* **Support interchangeable Control & Command Modifiers (#1817 Item 1, Part 2)**:
  * On macOS, Qt maps the Command key to `Qt::ControlModifier`. We now dynamically register fallbacks using the physical Control key (`Qt::MetaModifier`) for all default/custom Command key shortcuts.
   
* **Support interchangeable Delete & Backspace Keys (#1817 Item 2)**:
  * Mac keyboards typically feature a key labeled "delete" in place of Backspace, which produces `Qt::Key_Backspace`.
  * Added `Qt::Key_Backspace` as a dynamic runtime fallback for all shortcuts using `Qt::Key_Delete` (such as object removal, sheet removal, etc.) on macOS.
*Note: All fallback mappings are computed dynamically at runtime using `EditorCommand::getShortcutsWithMacFallbacks()`. This ensures the UI settings dialog, exported shortcut reference PDF, and tooltips remain clean and show only the primary shortcut.*

### Verification & Testing
* Built the project successfully with CMake (Qt 6).
* All 2591 unit tests build and pass successfully.
* Verified that on macOS:
  * Both `⌘ + Z` and `⌃ + Z` trigger Undo.
  * Both Backspace (labeled delete) and Fn + Delete keys successfully delete selected objects in the editors.
  * Tooltips and menus display clean modifier symbols (e.g. `⌘Z`).

Fixes #1817.