### PR TITLE
Fix locale-dependent formatting of attribute values

### DIFF
--- a/libs/librepcb/core/attribute/attrtypecapacitance.cpp
+++ b/libs/librepcb/core/attribute/attrtypecapacitance.cpp
@@ -73,14 +73,16 @@ QString AttrTypeCapacitance::valueFromTr(const QString& value) const noexcept {
 
 QString AttrTypeCapacitance::printableValueTr(
     const QString& value, const AttributeUnit* unit) const noexcept {
-  bool ok = false;
-  float v = value.toFloat(&ok);
-  if (ok && unit)
-    return QLocale().toString(v) % unit->getSymbolTr();
-  else if (ok)
-    return QLocale().toString(v);
-  else
-    return QString();
+  // Important: Do not format the number with the user's locale as this would
+  // make output files like schematics or even Gerber files non-deterministic.
+  // As we know the value is either empty or a valid number in 'C' locale, we
+  // can print it as-is, without any further validation or formatting.
+  // See: https://github.com/LibrePCB/LibrePCB/issues/1814
+  if (unit && (!value.isEmpty())) {
+    return value % unit->getSymbolTr();
+  } else {
+    return value;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/attribute/attrtypecurrent.cpp
+++ b/libs/librepcb/core/attribute/attrtypecurrent.cpp
@@ -78,14 +78,16 @@ QString AttrTypeCurrent::valueFromTr(const QString& value) const noexcept {
 
 QString AttrTypeCurrent::printableValueTr(
     const QString& value, const AttributeUnit* unit) const noexcept {
-  bool ok = false;
-  float v = value.toFloat(&ok);
-  if (ok && unit)
-    return QLocale().toString(v) % unit->getSymbolTr();
-  else if (ok)
-    return QLocale().toString(v);
-  else
-    return QString();
+  // Important: Do not format the number with the user's locale as this would
+  // make output files like schematics or even Gerber files non-deterministic.
+  // As we know the value is either empty or a valid number in 'C' locale, we
+  // can print it as-is, without any further validation or formatting.
+  // See: https://github.com/LibrePCB/LibrePCB/issues/1814
+  if (unit && (!value.isEmpty())) {
+    return value % unit->getSymbolTr();
+  } else {
+    return value;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/attribute/attrtypefrequency.cpp
+++ b/libs/librepcb/core/attribute/attrtypefrequency.cpp
@@ -76,14 +76,16 @@ QString AttrTypeFrequency::valueFromTr(const QString& value) const noexcept {
 
 QString AttrTypeFrequency::printableValueTr(
     const QString& value, const AttributeUnit* unit) const noexcept {
-  bool ok = false;
-  float v = value.toFloat(&ok);
-  if (ok && unit)
-    return QLocale().toString(v) % unit->getSymbolTr();
-  else if (ok)
-    return QLocale().toString(v);
-  else
-    return QString();
+  // Important: Do not format the number with the user's locale as this would
+  // make output files like schematics or even Gerber files non-deterministic.
+  // As we know the value is either empty or a valid number in 'C' locale, we
+  // can print it as-is, without any further validation or formatting.
+  // See: https://github.com/LibrePCB/LibrePCB/issues/1814
+  if (unit && (!value.isEmpty())) {
+    return value % unit->getSymbolTr();
+  } else {
+    return value;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/attribute/attrtypeinductance.cpp
+++ b/libs/librepcb/core/attribute/attrtypeinductance.cpp
@@ -71,14 +71,16 @@ QString AttrTypeInductance::valueFromTr(const QString& value) const noexcept {
 
 QString AttrTypeInductance::printableValueTr(
     const QString& value, const AttributeUnit* unit) const noexcept {
-  bool ok = false;
-  float v = value.toFloat(&ok);
-  if (ok && unit)
-    return QLocale().toString(v) % unit->getSymbolTr();
-  else if (ok)
-    return QLocale().toString(v);
-  else
-    return QString();
+  // Important: Do not format the number with the user's locale as this would
+  // make output files like schematics or even Gerber files non-deterministic.
+  // As we know the value is either empty or a valid number in 'C' locale, we
+  // can print it as-is, without any further validation or formatting.
+  // See: https://github.com/LibrePCB/LibrePCB/issues/1814
+  if (unit && (!value.isEmpty())) {
+    return value % unit->getSymbolTr();
+  } else {
+    return value;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/attribute/attrtypepower.cpp
+++ b/libs/librepcb/core/attribute/attrtypepower.cpp
@@ -78,14 +78,16 @@ QString AttrTypePower::valueFromTr(const QString& value) const noexcept {
 
 QString AttrTypePower::printableValueTr(
     const QString& value, const AttributeUnit* unit) const noexcept {
-  bool ok = false;
-  float v = value.toFloat(&ok);
-  if (ok && unit)
-    return QLocale().toString(v) % unit->getSymbolTr();
-  else if (ok)
-    return QLocale().toString(v);
-  else
-    return QString();
+  // Important: Do not format the number with the user's locale as this would
+  // make output files like schematics or even Gerber files non-deterministic.
+  // As we know the value is either empty or a valid number in 'C' locale, we
+  // can print it as-is, without any further validation or formatting.
+  // See: https://github.com/LibrePCB/LibrePCB/issues/1814
+  if (unit && (!value.isEmpty())) {
+    return value % unit->getSymbolTr();
+  } else {
+    return value;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/attribute/attrtyperesistance.cpp
+++ b/libs/librepcb/core/attribute/attrtyperesistance.cpp
@@ -70,14 +70,16 @@ QString AttrTypeResistance::valueFromTr(const QString& value) const noexcept {
 
 QString AttrTypeResistance::printableValueTr(
     const QString& value, const AttributeUnit* unit) const noexcept {
-  bool ok = false;
-  float v = value.toFloat(&ok);
-  if (ok && unit)
-    return QLocale().toString(v) % unit->getSymbolTr();
-  else if (ok)
-    return QLocale().toString(v);
-  else
-    return QString();
+  // Important: Do not format the number with the user's locale as this would
+  // make output files like schematics or even Gerber files non-deterministic.
+  // As we know the value is either empty or a valid number in 'C' locale, we
+  // can print it as-is, without any further validation or formatting.
+  // See: https://github.com/LibrePCB/LibrePCB/issues/1814
+  if (unit && (!value.isEmpty())) {
+    return value % unit->getSymbolTr();
+  } else {
+    return value;
+  }
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/attribute/attrtypevoltage.cpp
+++ b/libs/librepcb/core/attribute/attrtypevoltage.cpp
@@ -76,14 +76,16 @@ QString AttrTypeVoltage::valueFromTr(const QString& value) const noexcept {
 
 QString AttrTypeVoltage::printableValueTr(
     const QString& value, const AttributeUnit* unit) const noexcept {
-  bool ok = false;
-  float v = value.toFloat(&ok);
-  if (ok && unit)
-    return QLocale().toString(v) % unit->getSymbolTr();
-  else if (ok)
-    return QLocale().toString(v);
-  else
-    return QString();
+  // Important: Do not format the number with the user's locale as this would
+  // make output files like schematics or even Gerber files non-deterministic.
+  // As we know the value is either empty or a valid number in 'C' locale, we
+  // can print it as-is, without any further validation or formatting.
+  // See: https://github.com/LibrePCB/LibrePCB/issues/1814
+  if (unit && (!value.isEmpty())) {
+    return value % unit->getSymbolTr();
+  } else {
+    return value;
+  }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Always format attribute values with the 'C' locale (e.g. "1.5kΩ" instead of "1,5kΩ") to avoid generating locale-dependent renderings & output files. Any output files shall be deterministic & reproducible, no matter on which system they are generated. Especially production data like Gerber files, which were also affected by this problem if they contained attribute values with decimal separators.

Fixes #1814