### PR TITLE
UI: Accept locale-dependent decimal point in attribute values

### DIFF
--- a/libs/librepcb/editor/modelview/attributelistmodel.cpp
+++ b/libs/librepcb/editor/modelview/attributelistmodel.cpp
@@ -99,6 +99,11 @@ void AttributeListModel::apply() {
       // Clean value & remove unit suffix.
       value = value.trimmed();
       type->tryExtractUnitFromValue(value);
+      // Convert locale-dependent decimal point to 'C' decimal point, see
+      // also https://github.com/LibrePCB/LibrePCB/issues/1367.
+      if (!type->isValueValid(value)) {
+        value.replace(QLocale().decimalPoint(), ".");
+      }
     }
     const AttributeUnit* unit =
         type ? type->getAvailableUnits().value(item.unit) : nullptr;
@@ -202,6 +207,11 @@ void AttributeListModel::set_row_data(std::size_t i,
               type->tryExtractUnitFromValue(valueWithoutUnit)) {
         unit = newUnit;
         unitModified = true;
+      }
+      // Convert locale-dependent decimal point to 'C' decimal point, see
+      // also https://github.com/LibrePCB/LibrePCB/issues/1367.
+      if (type && (!type->isValueValid(valueWithoutUnit))) {
+        valueWithoutUnit.replace(QLocale().decimalPoint(), ".");
       }
     }
 

--- a/libs/librepcb/editor/modelview/attributelistmodellegacy.cpp
+++ b/libs/librepcb/editor/modelview/attributelistmodellegacy.cpp
@@ -355,6 +355,17 @@ bool AttributeListModelLegacy::setData(const QModelIndex& index,
       QString attrValue = value.toString().trimmed();
       const AttributeType* type = item ? &item->getType() : mNewType;
       const AttributeUnit* unit = type->tryExtractUnitFromValue(attrValue);
+      if (!type->isValueValid(attrValue)) {
+        // Convert locale-dependent decimal point to 'C' decimal point, see
+        // also https://github.com/LibrePCB/LibrePCB/issues/1367.
+        attrValue.replace(QLocale().decimalPoint(), ".");
+      }
+      if (!type->isValueValid(attrValue)) {
+        throw RuntimeError(
+            __FILE__, __LINE__,
+            QString("The value '%1' is not valid for attributes of type '%2'.")
+                .arg(attrValue, type->getNameTr()));
+      }
       if (cmd) {
         cmd->setValue(attrValue);
         if (unit) {


### PR DESCRIPTION
We already accept locale-dependent decimal separators in various input fields (see #1523), but not yet for attribute values. Now accepting e.g. "1,5kΩ" in addition to "1.5kΩ" on a system with de_DE locale. But since the decimal separator of attributes has to be locale-independent, the character is just replaced by '.' during input processing.

Also improved the error message when entering completely invalid attribute values.