### PR TITLE
Fix crash when canceling attributes overlay in device editor

### DIFF
--- a/libs/librepcb/ui/library/cat/categorytab.slint
+++ b/libs/librepcb/ui/library/cat/categorytab.slint
@@ -193,14 +193,16 @@ component CategoryTab inherits Tab {
         model: tabs[index].parents-tree;
 
         item-picked(idx, item) => {
-            tabs[index].new-parent = item.user-data;
-            tabs[index].choose-parent = false;
             root.focus();  // Keep keyboard shortcuts working.
+            tabs[index].new-parent = item.user-data;
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-parent = false;
         }
 
         rejected => {
-            tabs[index].choose-parent = false;
             root.focus();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-parent = false;
         }
     }
 }

--- a/libs/librepcb/ui/library/cmp/componenttab.slint
+++ b/libs/librepcb/ui/library/cmp/componenttab.slint
@@ -652,14 +652,16 @@ export component ComponentTab inherits Tab {
         model: tabs[index].categories-tree;
 
         item-picked(idx, item) => {
-            tabs[index].new-category = item.user-data;
-            tabs[index].choose-category = false;
             root.focus();  // Keep keyboard shortcuts working.
+            tabs[index].new-category = item.user-data;
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
 
         rejected => {
-            tabs[index].choose-category = false;
             root.focus();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
     }
 

--- a/libs/librepcb/ui/library/dev/devicetab.slint
+++ b/libs/librepcb/ui/library/dev/devicetab.slint
@@ -471,13 +471,15 @@ component DeviceContentTab {
 
         accepted => {
             Backend.trigger-tab(section-index, index, TabAction.apply);
-            attributes-editor-part-index = -1;
             move-focus-to-tab();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            attributes-editor-part-index = -1;
         }
 
         rejected => {
-            attributes-editor-part-index = -1;
             move-focus-to-tab();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            attributes-editor-part-index = -1;
         }
     }
 }
@@ -579,14 +581,16 @@ export component DeviceTab inherits Tab {
         model: tabs[index].categories-tree;
 
         item-picked(idx, item) => {
-            tabs[index].new-category = item.user-data;
-            tabs[index].choose-category = false;
             root.focus();  // Keep keyboard shortcuts working.
+            tabs[index].new-category = item.user-data;
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
 
         rejected => {
-            tabs[index].choose-category = false;
             root.focus();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
     }
 

--- a/libs/librepcb/ui/library/lib/librarytab.slint
+++ b/libs/librepcb/ui/library/lib/librarytab.slint
@@ -806,14 +806,16 @@ export component LibraryTab inherits Tab {
         model: tabs[index].dependencies;
 
         item-clicked(idx) => {
-            self.model[idx].checked = true;
-            show-add-dependency-dialog = false;
             root.focus();  // Keep keyboard shortcuts working.
+            self.model[idx].checked = true;
+            // Close the dialog *as the last operation* to avoid crashes!
+            show-add-dependency-dialog = false;
         }
 
         rejected => {
-            show-add-dependency-dialog = false;
             root.focus();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            show-add-dependency-dialog = false;
         }
     }
 
@@ -824,15 +826,17 @@ export component LibraryTab inherits Tab {
         hide-library-with-path: Data.libraries[tabs[index].library-index].path;
 
         item-clicked(path) => {
+            root.focus();  // Keep keyboard shortcuts working.
             tabs[index].move-or-copy-to-lib = path;
             tabs[index].move-or-copy-action = move-or-copy-action;
+            // Close the dialog *as the last operation* to avoid crashes!
             move-or-copy-action = LibraryElementsMoveAction.none;
-            root.focus();  // Keep keyboard shortcuts working.
         }
 
         rejected => {
-            move-or-copy-action = LibraryElementsMoveAction.none;
             root.focus();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            move-or-copy-action = LibraryElementsMoveAction.none;
         }
     }
 }

--- a/libs/librepcb/ui/library/pkg/packagetab.slint
+++ b/libs/librepcb/ui/library/pkg/packagetab.slint
@@ -1179,14 +1179,16 @@ export component PackageTab inherits Tab {
         model: tabs[index].categories-tree;
 
         item-picked(idx, item) => {
-            tabs[index].new-category = item.user-data;
-            tabs[index].choose-category = false;
             root.focus();  // Keep keyboard shortcuts working.
+            tabs[index].new-category = item.user-data;
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
 
         rejected => {
-            tabs[index].choose-category = false;
             root.focus();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
     }
 

--- a/libs/librepcb/ui/library/sym/symboltab.slint
+++ b/libs/librepcb/ui/library/sym/symboltab.slint
@@ -217,14 +217,16 @@ component SymbolMetadataTab {
         model: tabs[index].categories-tree;
 
         item-picked(idx, item) => {
-            tabs[index].new-category = item.user-data;
-            tabs[index].choose-category = false;
             move-focus-to-tab();  // Keep keyboard shortcuts working.
+            tabs[index].new-category = item.user-data;
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
 
         rejected => {
-            tabs[index].choose-category = false;
             move-focus-to-tab();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            tabs[index].choose-category = false;
         }
     }
 }

--- a/libs/librepcb/ui/project/library/projectlibrarytab.slint
+++ b/libs/librepcb/ui/project/library/projectlibrarytab.slint
@@ -567,14 +567,16 @@ export component ProjectLibraryTab inherits Tab {
         height: parent.height;
 
         item-clicked(path) => {
-            tabs[index].copy-to-library = path;
-            choose-library = false;
             root.focus();  // Keep keyboard shortcuts working.
+            tabs[index].copy-to-library = path;
+            // Close the dialog *as the last operation* to avoid crashes!
+            choose-library = false;
         }
 
         rejected => {
-            choose-library = false;
             root.focus();  // Keep keyboard shortcuts working.
+            // Close the dialog *as the last operation* to avoid crashes!
+            choose-library = false;
         }
     }
 

--- a/tests/ui/mainwindow/test_device_editor.py
+++ b/tests/ui/mainwindow/test_device_editor.py
@@ -5,6 +5,8 @@
 Test the device editor
 """
 
+from slint_testing import keys
+
 
 def test_open_package_and_component(librepcb):
     librepcb.add_local_library_to_workspace("libraries/Populated Library.lplib")
@@ -35,3 +37,29 @@ def test_open_package_and_component(librepcb):
         tabs.wait(4)
         assert tabs[-1].label == "Capacitor Bipolar"
         tabs[-1].mclick()
+
+
+# Regression test for a crash in LibrePCB 2.1.0.
+def test_part_attributes_editor_cancel(librepcb):
+    librepcb.add_local_library_to_workspace("libraries/Populated Library.lplib")
+    with librepcb.open() as app:
+        app.get("SideBar::libraries-btn").click()
+        app.get("LibrariesPanel::local-libs #LibraryListViewItem").dclick()
+        tabs = app.get("#TabButton *")
+
+        # Open device
+        items = app.get("LibraryContentTab::elements-view LibraryTreeView::item-ta *")
+        items.wait(2, None)
+        items[1].dclick()  # C-0805 device
+        tabs.wait(3)
+        assert tabs[-1].label == "C-0805"
+
+        # Open attributes editor of new part and focus the key edit
+        app.get("PartListView::attributes-ta").click()
+        overlay = app.get("DeviceContentTab::attributes-overlay")
+        overlay.get("AttributeListView::key-edt").click()
+
+        # Close the attributes editor with the Escape key and verify that this
+        # closes the overlay. This operation caused a crash in LibrePCB 2.1.0.
+        app.trigger_shortcut([keys.Escape])
+        overlay.wait_for(valid=False)


### PR DESCRIPTION
Fixing a crash in Slint when pressing Escape while the part attributes editor overlay in the device editor was opened and had focus.