### PR TITLE
SES import: Fix incompatibility with recent FreeRouting versions

### DIFF
--- a/libs/librepcb/core/serialization/sexpression.cpp
+++ b/libs/librepcb/core/serialization/sexpression.cpp
@@ -92,10 +92,10 @@ const SExpression& SExpression::getChild(int index) const {
   return *mChildren.at(index);
 }
 
-const QList<SExpression*> SExpression::getChildren(Type type) noexcept {
+const QList<SExpression*> SExpression::getChildren(TypeFilter types) noexcept {
   QList<SExpression*> children;
   for (const auto& child : mChildren) {
-    if (child->getType() == type) {
+    if (types.testFlag(child->getType())) {
       children.append(child.get());
     }
   }
@@ -103,10 +103,10 @@ const QList<SExpression*> SExpression::getChildren(Type type) noexcept {
 }
 
 const QList<const SExpression*> SExpression::getChildren(
-    Type type) const noexcept {
+    TypeFilter types) const noexcept {
   QList<const SExpression*> children;
   for (const auto& child : mChildren) {
-    if (child->getType() == type) {
+    if (types.testFlag(child->getType())) {
       children.append(child.get());
     }
   }

--- a/libs/librepcb/core/serialization/sexpression.h
+++ b/libs/librepcb/core/serialization/sexpression.h
@@ -75,12 +75,13 @@ public:
     LibrePCB,  ///< LibrePCB syntax (very strict)
     Permissive,  ///< Compatibility with other tools (very permissive)
   };
-  enum class Type {
-    List,  ///< has a tag name and an arbitrary number of children
-    Token,  ///< values without quotes (e.g. `-12.34`)
-    String,  ///< values with double quotes (e.g. `"Foo!"`)
-    LineBreak,  ///< manual line break inside a List
+  enum class Type : uint32_t {
+    List = (1 << 0),  ///< has a tag name and an arbitrary number of children
+    Token = (1 << 1),  ///< values without quotes (e.g. `-12.34`)
+    String = (1 << 2),  ///< values with double quotes (e.g. `"Foo!"`)
+    LineBreak = (1 << 3),  ///< manual line break inside a List
   };
+  Q_DECLARE_FLAGS(TypeFilter, Type)
 
   // Constructors / Destructor
   SExpression() noexcept;
@@ -100,8 +101,8 @@ public:
   bool containsChild(const SExpression& child) const noexcept;
   SExpression& getChild(int index);
   const SExpression& getChild(int index) const;
-  const QList<SExpression*> getChildren(Type type) noexcept;
-  const QList<const SExpression*> getChildren(Type type) const noexcept;
+  const QList<SExpression*> getChildren(TypeFilter types) noexcept;
+  const QList<const SExpression*> getChildren(TypeFilter types) const noexcept;
   const QList<SExpression*> getChildren(const QString& name) noexcept;
   const QList<const SExpression*> getChildren(
       const QString& name) const noexcept;
@@ -253,5 +254,7 @@ uint qHash(const std::unique_ptr<SExpression>& ptr, uint seed = 0) noexcept;
  ******************************************************************************/
 
 }  // namespace librepcb
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(librepcb::SExpression::TypeFilter)
 
 #endif

--- a/libs/librepcb/editor/project/cmd/cmdboardspecctraimport.cpp
+++ b/libs/librepcb/editor/project/cmd/cmdboardspecctraimport.cpp
@@ -235,11 +235,14 @@ CmdBoardSpecctraImport::CmdBoardSpecctraImport(
     }
     for (const SExpression* wireNode : netNode->getChildren("wire")) {
       for (const SExpression* pathNode : wireNode->getChildren("path")) {
-        QList<const SExpression*> children =
-            pathNode->getChildren(SExpression::Type::Token);
+        QList<const SExpression*> children = pathNode->getChildren(
+            SExpression::Type::Token | SExpression::Type::String);
         if ((children.count() < 2) || ((children.count() % 2) != 0)) {
           throw RuntimeError(__FILE__, __LINE__,
-                             "Unexpected number of vertices in path element.");
+                             QString("Unexpected number of vertices (%1) in "
+                                     "wire path of net '%2'.")
+                                 .arg(children.count())
+                                 .arg(net.netName));
         }
         WireOut wire{deserialize<const Layer*>(*children.at(0)),
                      parseLength(*children.at(1), resolution),

--- a/tests/unittests/editor/project/board/cmdboardspecctraimporttest.cpp
+++ b/tests/unittests/editor/project/board/cmdboardspecctraimporttest.cpp
@@ -41,16 +41,25 @@ namespace editor {
 namespace tests {
 
 /*******************************************************************************
+ *  Test Data Type
+ ******************************************************************************/
+
+typedef struct {
+  const char* sesFileName;
+} TestData;
+
+/*******************************************************************************
  *  Test Class
  ******************************************************************************/
 
-class CmdBoardSpecctraImportTest : public ::testing::Test {};
+class CmdBoardSpecctraImportTest : public ::testing::TestWithParam<TestData> {};
 
 /*******************************************************************************
  *  Test Methods
  ******************************************************************************/
 
-TEST_F(CmdBoardSpecctraImportTest, test) {
+TEST_P(CmdBoardSpecctraImportTest, test) {
+  const TestData& data = GetParam();
   FilePath testDataDir(TEST_DATA_DIR
                        "/unittests/librepcbproject/BoardSpecctraExportTest");
 
@@ -64,7 +73,7 @@ TEST_F(CmdBoardSpecctraImportTest, test) {
                   projectFp.getFilename());  // can throw
 
   // Load SES.
-  const FilePath fp = testDataDir.getPathTo("session.ses");
+  const FilePath fp = testDataDir.getPathTo(data.sesFileName);
   std::unique_ptr<SExpression> root = SExpression::parse(
       FileUtils::readFile(fp), fp, SExpression::Mode::Permissive);
 
@@ -75,6 +84,16 @@ TEST_F(CmdBoardSpecctraImportTest, test) {
   const bool ret = imp.execute();
   EXPECT_TRUE(ret);
 }
+
+/*******************************************************************************
+ *  Test Data
+ ******************************************************************************/
+
+// NOLINTNEXTLINE
+INSTANTIATE_TEST_SUITE_P(
+    CmdBoardSpecctraImportTest, CmdBoardSpecctraImportTest,
+    ::testing::Values(TestData({"session_freerouting_old.ses"}),
+                      TestData({"session_freerouting_2.4.0.ses"})));
 
 /*******************************************************************************
  *  End of File


### PR DESCRIPTION
We expected the net name in the SES to appear as an S-Expression token, instead of accepting quoted strings too. Since FreeRouting has switched from tokens to quoted string, this broke our import. Now accepting both, tokens and quoted strings.
