### PR TITLE
Show native modifier key text on macOS

### DIFF
--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawpolygonbase.cpp
@@ -537,8 +537,8 @@ void PackageEditorState_DrawPolygonBase::updateOverlayText() noexcept {
 void PackageEditorState_DrawPolygonBase::updateStatusBarMessage() noexcept {
   QString note = " " %
       tr("(press %1 to disable snap, %2 to abort)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift") % "/" %
-               QCoreApplication::translate("QShortcut", "Ctrl"))
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier) % "/" %
+               EditorToolbox::modifierKeyText(Qt::ControlModifier))
           .arg(tr("right click"));
 
   if (mMode == Mode::RECT) {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_drawzone.cpp
@@ -25,6 +25,7 @@
 #include "../../../cmd/cmdzoneedit.h"
 #include "../../../graphics/zonegraphicsitem.h"
 #include "../../../undostack.h"
+#include "../../../utils/editortoolbox.h"
 #include "../footprintgraphicsitem.h"
 
 #include <librepcb/core/library/pkg/footprint.h>
@@ -359,7 +360,7 @@ void PackageEditorState_DrawZone::updateOverlayText() noexcept {
 void PackageEditorState_DrawZone::updateStatusBarMessage() noexcept {
   QString note = " " %
       tr("(press %1 to disable snap, %2 to abort)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift"),
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier),
                tr("right click"));
 
   if (!mIsUndoCmdActive) {

--- a/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.cpp
+++ b/libs/librepcb/editor/library/pkg/fsm/packageeditorstate_renumberpads.cpp
@@ -24,6 +24,7 @@
 
 #include "../../../undocommandgroup.h"
 #include "../../../undostack.h"
+#include "../../../utils/editortoolbox.h"
 #include "../../cmd/cmdfootprintpadedit.h"
 #include "../footprintgraphicsitem.h"
 #include "../footprintpadgraphicsitem.h"
@@ -74,8 +75,8 @@ bool PackageEditorState_ReNumberPads::entry() noexcept {
   const QString note = " " %
       tr("(press %1 for single-selection, %2 to change numbering mode, %3 to "
          "finish)")
-          .arg(QCoreApplication::translate("QShortcut", "Ctrl"),
-               QCoreApplication::translate("QShortcut", "Shift"),
+          .arg(EditorToolbox::modifierKeyText(Qt::ControlModifier),
+               EditorToolbox::modifierKeyText(Qt::ShiftModifier),
                QCoreApplication::translate("QShortcut", "Return"));
   mAdapter.fsmSetStatusBarMessage(tr("Click on the next pad") % note);
   mAdapter.fsmSetViewCursor(Qt::PointingHandCursor);

--- a/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
+++ b/libs/librepcb/editor/library/sym/fsm/symboleditorstate_drawpolygonbase.cpp
@@ -526,8 +526,8 @@ void SymbolEditorState_DrawPolygonBase::updateOverlayText() noexcept {
 void SymbolEditorState_DrawPolygonBase::updateStatusBarMessage() noexcept {
   QString note = " " %
       tr("(press %1 to disable snap, %2 to abort)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift") % "/" %
-               QCoreApplication::translate("QShortcut", "Ctrl"))
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier) % "/" %
+               EditorToolbox::modifierKeyText(Qt::ControlModifier))
           .arg(tr("right click"));
 
   if (mMode == Mode::RECT) {

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.cpp
@@ -24,6 +24,7 @@
 
 #include "../../../editorcommandset.h"
 #include "../../../undostack.h"
+#include "../../../utils/editortoolbox.h"
 #include "../../cmd/cmdchangenetsignalofschematicnetsegment.h"
 #include "../../cmd/cmdcombineschematicnetsegments.h"
 #include "../../cmd/cmdcompsiginstsetnetsignal.h"
@@ -851,8 +852,9 @@ std::optional<NetSignal*>
   menu.setDefaultAction(
       menu.addAction(QIcon(":/img/actions/draw_wire.png"),
                      tr("Add New Bus Member") +
-                         QString(" (%1)").arg(QCoreApplication::translate(
-                             "QShortcut", "Ctrl"))));
+                         QString(" (%1)").arg(
+                             EditorToolbox::modifierKeyText(
+                                 Qt::ControlModifier))));
   NetSignal* selectedNet = nullptr;
   for (NetSignal* net : std::as_const(nets)) {
     QAction* a =

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_drawwire.cpp
@@ -849,12 +849,11 @@ std::optional<NetSignal*>
                          }
                        });
   QMenu menu;
-  menu.setDefaultAction(
-      menu.addAction(QIcon(":/img/actions/draw_wire.png"),
-                     tr("Add New Bus Member") +
-                         QString(" (%1)").arg(
-                             EditorToolbox::modifierKeyText(
-                                 Qt::ControlModifier))));
+  menu.setDefaultAction(menu.addAction(
+      QIcon(":/img/actions/draw_wire.png"),
+      tr("Add New Bus Member") +
+          QString(" (%1)").arg(
+              EditorToolbox::modifierKeyText(Qt::ControlModifier))));
   NetSignal* selectedNet = nullptr;
   for (NetSignal* net : std::as_const(nets)) {
     QAction* a =

--- a/libs/librepcb/editor/utils/editortoolbox.cpp
+++ b/libs/librepcb/editor/utils/editortoolbox.cpp
@@ -152,6 +152,39 @@ bool EditorToolbox::isSystemThemeDark() noexcept {
   return value;
 }
 
+QString EditorToolbox::modifierKeyText(Qt::KeyboardModifier modifier) noexcept {
+#if defined(Q_OS_MACOS)
+  // Use the native symbols which macOS users are familiar with. Note that on
+  // macOS Qt::ControlModifier corresponds to the Command key (not the physical
+  // Control key), which is exactly the key triggering the action.
+  switch (modifier) {
+    case Qt::ControlModifier:
+      return QStringLiteral("⌘");  // ⌘ Command (Place of Interest Sign)
+    case Qt::ShiftModifier:
+      return QStringLiteral("⇧");  // ⇧ Shift (Upwards White Arrow)
+    case Qt::AltModifier:
+      return QStringLiteral("⌥");  // ⌥ Option
+    case Qt::MetaModifier:
+      return QStringLiteral("⌃");  // ⌃ Control (Up Arrowhead)
+    default:
+      break;
+  }
+#endif
+  switch (modifier) {
+    case Qt::ControlModifier:
+      return QCoreApplication::translate("QShortcut", "Ctrl");
+    case Qt::ShiftModifier:
+      return QCoreApplication::translate("QShortcut", "Shift");
+    case Qt::AltModifier:
+      return QCoreApplication::translate("QShortcut", "Alt");
+    case Qt::MetaModifier:
+      return QCoreApplication::translate("QShortcut", "Meta");
+    default:
+      qWarning() << "Unhandled modifier in EditorToolbox::modifierKeyText().";
+      return QString();
+  }
+}
+
 QString EditorToolbox::toSingleLine(const QString& s) noexcept {
   return QString(s).replace("\n", "\\n");
 }

--- a/libs/librepcb/editor/utils/editortoolbox.h
+++ b/libs/librepcb/editor/utils/editortoolbox.h
@@ -80,6 +80,22 @@ public:
   static bool isSystemThemeDark() noexcept;
 
   /**
+   * @brief Get the platform-specific display text for a keyboard modifier
+   *
+   * Intended for messages which refer to a modifier key (e.g. "press Ctrl to
+   * ..."). On macOS, the corresponding symbol (e.g. "⌘" for Control) is
+   * returned to match the native look & feel and the key which is actually
+   * used (the Command key is mapped to Qt::ControlModifier on macOS, while
+   * the physical Control key does not trigger the action). On other platforms,
+   * the textual name (e.g. "Ctrl") is returned.
+   *
+   * @param modifier  The keyboard modifier (e.g. Qt::ControlModifier).
+   *
+   * @return The display text for the given modifier.
+   */
+  static QString modifierKeyText(Qt::KeyboardModifier modifier) noexcept;
+
+  /**
    * @brief Escape newlines to convert a multi-line to a single-line string
    *
    * @param s     Input string.

--- a/libs/librepcb/editor/utils/measuretool.cpp
+++ b/libs/librepcb/editor/utils/measuretool.cpp
@@ -417,7 +417,7 @@ void MeasureTool::updateStatusBarMessage() noexcept {
       EditorCommandSet::instance().remove.getKeySequences();
   const QString disableSnapNote = " " %
       tr("(press %1 to disable snap)")
-          .arg(QCoreApplication::translate("QShortcut", "Shift"));
+          .arg(EditorToolbox::modifierKeyText(Qt::ShiftModifier));
 
   if (mEndPos && (!copyKeys.isEmpty()) && (!deleteKeys.isEmpty())) {
     emit statusBarMessageChanged(

--- a/libs/librepcb/ui/mainmenubar.slint
+++ b/libs/librepcb/ui/mainmenubar.slint
@@ -431,10 +431,8 @@ export component MainMenuBar {
                 }
 
                 cut-item := MenuItem {
-                    text: @tr("Cut");
+                    cmd: Cmd.clipboard-cut;
                     icon: @image-url("../../font-awesome/svgs/solid/scissors.svg");
-                    status-tip: @tr("Cut the selected object(s) to clipboard");
-                    shortcuts: "Ctrl+X";
                     enabled: Data.current-tab.features.cut == FeatureState.enabled;
 
                     clicked => {
@@ -444,10 +442,8 @@ export component MainMenuBar {
                 }
 
                 copy-item := MenuItem {
-                    text: @tr("Copy");
+                    cmd: Cmd.clipboard-copy;
                     icon: @image-url("../../font-awesome/svgs/regular/copy.svg");
-                    status-tip: @tr("Copy the selected object(s) to clipboard");
-                    shortcuts: "Ctrl+C";
                     enabled: Data.current-tab.features.copy == FeatureState.enabled;
 
                     clicked => {
@@ -457,10 +453,8 @@ export component MainMenuBar {
                 }
 
                 paste-item := MenuItem {
-                    text: @tr("Paste");
+                    cmd: Cmd.clipboard-paste;
                     icon: @image-url("../../font-awesome/svgs/solid/paste.svg");
-                    status-tip: @tr("Paste object(s) from the clipboard");
-                    shortcuts: "Ctrl+V";
                     enabled: Data.current-tab.features.paste == FeatureState.enabled;
 
                     clicked => {


### PR DESCRIPTION
This is a subset of PR #1832 which adds `EditorToolbox::modifierKeyText()` to display platform-specific keyboard modifier text in editor messages.

On macOS, modifier keys are shown with native symbols such as `⌘` and `⇧`, matching the actual keys used by Qt shortcuts. On other platforms, the existing translated text such as `Ctrl` and `Shift` is kept.

Also removes duplicated Cut/Copy/Paste menu item text, status tips and shortcut strings from `mainmenubar.slint` by binding these items to their existing editor commands while keeping their SVG icons.

This intentionally does not include the macOS shortcut fallback changes from the original branch.

