### PR TITLE
MacOS: Fix inconsistent/invalid rendering of modifier keys

### DIFF
--- a/libs/librepcb/editor/utils/uihelpers.cpp
+++ b/libs/librepcb/editor/utils/uihelpers.cpp
@@ -310,7 +310,7 @@ ui::EditorCommand l2s(const EditorCommand& cmd, ui::EditorCommand in) noexcept {
   in.status_tip = q2s(cmd.getDescription());
   const QKeySequence shortcut = cmd.getKeySequences().value(0);
   if (shortcut.count() == 1) {
-    in.shortcut = q2s(shortcut.toString());
+    in.shortcut = q2s(shortcut.toString(QKeySequence::NativeText));
     in.modifiers = q2s(shortcut[0].keyboardModifiers());
     in.key = q2s(shortcut[0].key());
     if (in.modifiers.shift && (in.key.size() == 1) &&


### PR DESCRIPTION
See https://github.com/LibrePCB/LibrePCB/pull/1846#issuecomment-4657799346.

Font changes: 
- https://github.com/LibrePCB/librepcb-fonts/commit/7d8484991260c3e661e25fe9c520b641f217919d
- https://github.com/LibrePCB/librepcb-fonts/commit/065a68a2301434738f9282e9115db63abb298a57