### PR TITLE
When changing grid style in status bar, apply it globally

### DIFF
--- a/libs/librepcb/core/workspace/workspacesettings.cpp
+++ b/libs/librepcb/core/workspace/workspacesettings.cpp
@@ -233,6 +233,15 @@ void WorkspaceSettings::restoreDefaults() noexcept {
   mFileContent.clear();  // Remove even unknown settings!
 }
 
+bool WorkspaceSettings::isEdited() const noexcept {
+  foreach (const WorkspaceSettingsItem* item, getAllItems()) {
+    if (item->isEdited()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::unique_ptr<SExpression> WorkspaceSettings::serialize() {
   foreach (const WorkspaceSettingsItem* item, getAllItems()) {
     if (item->isEdited() || mUpgradeRequired) {

--- a/libs/librepcb/core/workspace/workspacesettings.h
+++ b/libs/librepcb/core/workspace/workspacesettings.h
@@ -91,6 +91,16 @@ public:
   void restoreDefaults() noexcept;
 
   /**
+   * @brief Check if any of the settings has been edited
+   *
+   * @retval true   Settings have been modified.
+   * @retval false  Settings not modified.
+   *
+   * @see ::librepcb::WorkspaceSettingsItem::isEdited()
+   */
+  bool isEdited() const noexcept;
+
+  /**
    * @brief Serialize settings to ::librepcb::SExpression
    *
    * @return ::librepcb::SExpression node containing all settings.

--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -393,6 +393,18 @@ void GuiApplication::execWorkspaceSettingsDialog(QWidget* parent) noexcept {
   dlg.exec();
 }
 
+void GuiApplication::scheduleWorkspaceSettingsSave() noexcept {
+  QTimer::singleShot(3000, this, [this]() {
+    try {
+      if (mWorkspace.getSettings().isEdited()) {
+        mWorkspace.saveSettings();  // can throw
+      }
+    } catch (const Exception& e) {
+      qCritical() << "Failed to save workspace settings:" << e.getMsg();
+    }
+  });
+}
+
 void GuiApplication::addExampleProjects(QWidget* parent) noexcept {
   const QString msg =
       tr("This downloads some example projects from the internet and copies "

--- a/libs/librepcb/editor/guiapplication.h
+++ b/libs/librepcb/editor/guiapplication.h
@@ -81,6 +81,7 @@ public:
   void openFile(const FilePath& fp, QWidget* parent) noexcept;
   void switchWorkspace(QWidget* parent) noexcept;
   void execWorkspaceSettingsDialog(QWidget* parent) noexcept;
+  void scheduleWorkspaceSettingsSave() noexcept;
   void addExampleProjects(QWidget* parent) noexcept;
 
   // General

--- a/libs/librepcb/editor/library/pkg/packagetab.cpp
+++ b/libs/librepcb/editor/library/pkg/packagetab.cpp
@@ -113,7 +113,6 @@ PackageTab::PackageTab(LibraryEditor& editor, std::unique_ptr<Package> pkg,
     mWizardMode(mode != Mode::Open),
     mCurrentPageIndex(mWizardMode ? 0 : 2),
     mView3d(false),
-    mGridStyle(mApp.getWorkspace().getSettings().boardGridStyle.get()),
     mUnit(LengthUnit::millimeters()),
     mChooseCategory(false),
     mElementDuplicated(false),
@@ -213,10 +212,8 @@ PackageTab::PackageTab(LibraryEditor& editor, std::unique_ptr<Package> pkg,
 
   // Apply workspace settings whenever they have been modified.
   connect(&mApp.getWorkspace().getSettings().boardGridStyle,
-          &WorkspaceSettingsItem::edited, this, [this]() {
-            mGridStyle = mApp.getWorkspace().getSettings().boardGridStyle.get();
-            applyWorkspaceSettings();
-          });
+          &WorkspaceSettingsItem::edited, this,
+          &PackageTab::applyWorkspaceSettings);
   connect(&mApp.getWorkspace().getSettings().boardColorSchemes,
           &WorkspaceSettingsItem_ColorSchemes::edited, this,
           &PackageTab::applyWorkspaceSettings);
@@ -378,7 +375,7 @@ ui::PackageTabData PackageTab::getDerivedUiData() const noexcept {
       q2s(fgColor),  // Foreground color
       q2s(infoBoxColors.primary),  // Overlay color
       q2s(infoBoxColors.secondary),  // Overlay text color
-      l2s(mGridStyle),  // Grid style
+      l2s(mApp.getWorkspace().getSettings().boardGridStyle.get()),  // Grid
       l2s(*mPackage->getGridInterval()),  // Grid interval
       l2s(mUnit),  // Unit
       mBackgroundImageGraphicsItem->isVisible(),  // Background image set
@@ -519,13 +516,19 @@ void PackageTab::setDerivedUiData(const ui::PackageTabData& data) noexcept {
   }
 
   // View
-  mGridStyle = s2l(data.grid_style);
+  const GridStyle gridStyle = s2l(data.grid_style);
+  if (gridStyle != mApp.getWorkspace().getSettings().boardGridStyle.get()) {
+    // Grid style setting used to be per-tab, but that is annoying for the
+    // use-case of temporarily hiding the grid for presenting a schematic to
+    // other people or for taking screenshots, since this has to be done for
+    // each tab again. Also it can be surprising that this UI setting is not
+    // persistent. It is probably much more intuitive to apply this setting
+    // to all tabs immediately, and storing it in the workspace settings.
+    mApp.getWorkspace().getSettings().boardGridStyle.set(gridStyle);
+    mApp.scheduleWorkspaceSettingsSave();
+  }
   if (auto interval = s2plength(data.grid_interval)) {
     setGridInterval(*interval);
-  }
-  if (mScene) {
-    mScene->setGridStyle(mGridStyle);
-    mScene->setGridInterval(mPackage->getGridInterval());
   }
   const LengthUnit unit = s2l(data.unit);
   if (unit != mUnit) {
@@ -2816,21 +2819,21 @@ void PackageTab::requestRepaint() noexcept {
 }
 
 void PackageTab::applyWorkspaceSettings() noexcept {
+  const WorkspaceSettings& settings = mApp.getWorkspace().getSettings();
+
   if (mScene) {
-    const ColorScheme& scheme =
-        mApp.getWorkspace().getSettings().boardColorSchemes.getActive();
+    const ColorScheme& scheme = settings.boardColorSchemes.getActive();
     const auto background = scheme.getColors(ColorRole::boardBackground());
     mScene->setBackgroundColors(background.primary, background.secondary);
     const auto overlay = scheme.getColors(ColorRole::boardOverlays());
     mScene->setOverlayColors(overlay.primary, overlay.secondary);
     const auto selection = scheme.getColors(ColorRole::boardSelection());
     mScene->setSelectionRectColors(selection.primary, selection.secondary);
-    mScene->setGridStyle(mGridStyle);
+    mScene->setGridStyle(settings.boardGridStyle.get());
   }
 
   if (mOpenGlView) {
-    const ColorScheme& scheme =
-        mApp.getWorkspace().getSettings().view3dColorSchemes.getActive();
+    const ColorScheme& scheme = settings.view3dColorSchemes.getActive();
     const auto background = scheme.getColors(ColorRole::board3dBackground());
     mOpenGlView->setBackgroundColor(background.primary);
   }

--- a/libs/librepcb/editor/library/pkg/packagetab.h
+++ b/libs/librepcb/editor/library/pkg/packagetab.h
@@ -36,7 +36,6 @@
 #include <librepcb/core/library/pkg/package.h>
 #include <librepcb/core/types/alignment.h>
 #include <librepcb/core/types/elementname.h>
-#include <librepcb/core/types/enums.h>
 #include <librepcb/core/types/length.h>
 #include <librepcb/core/types/lengthunit.h>
 #include <librepcb/core/types/version.h>
@@ -235,7 +234,6 @@ private:
   bool mWizardMode;
   int mCurrentPageIndex;
   bool mView3d;
-  GridStyle mGridStyle;
   LengthUnit mUnit;
   bool mChooseCategory;
   bool mElementDuplicated;

--- a/libs/librepcb/editor/library/sym/symboltab.cpp
+++ b/libs/librepcb/editor/library/sym/symboltab.cpp
@@ -95,7 +95,6 @@ SymbolTab::SymbolTab(LibraryEditor& editor, std::unique_ptr<Symbol> sym,
     mMsgImportPins(mApp.getWorkspace(), "EMPTY_SYMBOL_IMPORT_PINS"),
     mWizardMode(mode != Mode::Open),
     mCurrentPageIndex(mWizardMode ? 0 : 1),
-    mGridStyle(mApp.getWorkspace().getSettings().schematicGridStyle.get()),
     mUnit(LengthUnit::millimeters()),
     mChooseCategory(false),
     mElementDuplicated(false),
@@ -156,11 +155,8 @@ SymbolTab::SymbolTab(LibraryEditor& editor, std::unique_ptr<Symbol> sym,
 
   // Apply workspace settings whenever they have been modified.
   connect(&mApp.getWorkspace().getSettings().schematicGridStyle,
-          &WorkspaceSettingsItem::edited, this, [this]() {
-            mGridStyle =
-                mApp.getWorkspace().getSettings().schematicGridStyle.get();
-            applyWorkspaceSettings();
-          });
+          &WorkspaceSettingsItem::edited, this,
+          &SymbolTab::applyWorkspaceSettings);
   connect(&mApp.getWorkspace().getSettings().schematicColorSchemes,
           &WorkspaceSettingsItem_ColorSchemes::colorsModified, this,
           &SymbolTab::applyWorkspaceSettings);
@@ -290,7 +286,7 @@ ui::SymbolTabData SymbolTab::getDerivedUiData() const noexcept {
       q2s(fgColor),  // Foreground color
       q2s(infoBoxColors.primary),  // Overlay color
       q2s(infoBoxColors.secondary),  // Overlay text color
-      l2s(mGridStyle),  // Grid style
+      l2s(mApp.getWorkspace().getSettings().schematicGridStyle.get()),  // Grid
       l2s(*mSymbol->getGridInterval()),  // Grid interval
       l2s(mUnit),  // Unit
       !mModifiedWatchedFiles.isEmpty(),  // Watched files modified
@@ -363,13 +359,19 @@ void SymbolTab::setDerivedUiData(const ui::SymbolTabData& data) noexcept {
   mChooseCategory = data.choose_category;
 
   // View
-  mGridStyle = s2l(data.grid_style);
+  const GridStyle gridStyle = s2l(data.grid_style);
+  if (gridStyle != mApp.getWorkspace().getSettings().schematicGridStyle.get()) {
+    // Grid style setting used to be per-tab, but that is annoying for the
+    // use-case of temporarily hiding the grid for presenting a schematic to
+    // other people or for taking screenshots, since this has to be done for
+    // each tab again. Also it can be surprising that this UI setting is not
+    // persistent. It is probably much more intuitive to apply this setting
+    // to all tabs immediately, and storing it in the workspace settings.
+    mApp.getWorkspace().getSettings().schematicGridStyle.set(gridStyle);
+    mApp.scheduleWorkspaceSettingsSave();
+  }
   if (auto interval = s2plength(data.grid_interval)) {
     setGridInterval(*interval);
-  }
-  if (mScene) {
-    mScene->setGridStyle(mGridStyle);
-    mScene->setGridInterval(mSymbol->getGridInterval());
   }
   const LengthUnit unit = s2l(data.unit);
   if (unit != mUnit) {
@@ -1681,8 +1683,8 @@ void SymbolTab::requestRepaint() noexcept {
 }
 
 void SymbolTab::applyWorkspaceSettings() noexcept {
-  const ColorScheme& scheme =
-      mApp.getWorkspace().getSettings().schematicColorSchemes.getActive();
+  const WorkspaceSettings& settings = mApp.getWorkspace().getSettings();
+  const ColorScheme& scheme = settings.schematicColorSchemes.getActive();
 
   if (mScene) {
     const auto background = scheme.getColors(ColorRole::schematicBackground());
@@ -1691,7 +1693,7 @@ void SymbolTab::applyWorkspaceSettings() noexcept {
     mScene->setOverlayColors(overlay.primary, overlay.secondary);
     const auto selection = scheme.getColors(ColorRole::schematicSelection());
     mScene->setSelectionRectColors(selection.primary, selection.secondary);
-    mScene->setGridStyle(mGridStyle);
+    mScene->setGridStyle(settings.schematicGridStyle.get());
   }
 
   onDerivedUiDataChanged.notify();

--- a/libs/librepcb/editor/library/sym/symboltab.h
+++ b/libs/librepcb/editor/library/sym/symboltab.h
@@ -32,7 +32,6 @@
 
 #include <librepcb/core/types/alignment.h>
 #include <librepcb/core/types/elementname.h>
-#include <librepcb/core/types/enums.h>
 #include <librepcb/core/types/length.h>
 #include <librepcb/core/types/lengthunit.h>
 #include <librepcb/core/types/uuid.h>
@@ -209,7 +208,6 @@ private:
   // State
   bool mWizardMode;
   int mCurrentPageIndex;
-  GridStyle mGridStyle;
   LengthUnit mUnit;
   bool mChooseCategory;
   bool mElementDuplicated;

--- a/libs/librepcb/editor/project/board/board2dtab.cpp
+++ b/libs/librepcb/editor/project/board/board2dtab.cpp
@@ -165,7 +165,6 @@ Board2dTab::Board2dTab(GuiApplication& app, BoardEditor& editor,
         GraphicsLayer::State::Highlighted,  // Self-probe mode
         false,  // flip view
     }),
-    mGridStyle(mApp.getWorkspace().getSettings().boardGridStyle.get()),
     mIgnorePlacementLocks(false),
     mFrameIndex(0),
     mToolFeatures(),
@@ -291,10 +290,8 @@ Board2dTab::Board2dTab(GuiApplication& app, BoardEditor& editor,
 
   // Apply workspace settings whenever they have been modified.
   connect(&mApp.getWorkspace().getSettings().boardGridStyle,
-          &WorkspaceSettingsItem::edited, this, [this]() {
-            mGridStyle = mApp.getWorkspace().getSettings().boardGridStyle.get();
-            applyWorkspaceSettings();
-          });
+          &WorkspaceSettingsItem::edited, this,
+          &Board2dTab::applyWorkspaceSettings);
   connect(&mApp.getWorkspace().getSettings().boardColorSchemes,
           &WorkspaceSettingsItem_ColorSchemes::edited, this,
           &Board2dTab::applyWorkspaceSettings);
@@ -382,7 +379,7 @@ ui::Board2dTabData Board2dTab::getDerivedUiData() const noexcept {
       q2s(fgColor),  // Foreground color
       q2s(infoBoxColors.primary),  // Overlay color
       q2s(infoBoxColors.secondary),  // Overlay text color
-      l2s(mGridStyle),  // Grid style
+      l2s(mApp.getWorkspace().getSettings().boardGridStyle.get()),  // Grid
       l2s(*mBoard.getGridInterval()),  // Grid interval
       l2s(mBoard.getGridUnit()),  // Length unit
       mScene->isFlipped(),  // Flip view (view from bottom)
@@ -461,15 +458,24 @@ ui::Board2dTabData Board2dTab::getDerivedUiData() const noexcept {
 void Board2dTab::setDerivedUiData(const ui::Board2dTabData& data) noexcept {
   mSceneImagePos = s2q(data.scene_image_pos);
 
-  mGridStyle = s2l(data.grid_style);
+  const GridStyle gridStyle = s2l(data.grid_style);
+  if (gridStyle != mApp.getWorkspace().getSettings().boardGridStyle.get()) {
+    // Grid style setting used to be per-tab, but that is annoying for the
+    // use-case of temporarily hiding the grid for presenting a schematic to
+    // other people or for taking screenshots, since this has to be done for
+    // each tab again. Also it can be surprising that this UI setting is not
+    // persistent. It is probably much more intuitive to apply this setting
+    // to all tabs immediately, and storing it in the workspace settings.
+    mApp.getWorkspace().getSettings().boardGridStyle.set(gridStyle);
+    mApp.scheduleWorkspaceSettingsSave();
+  }
   const std::optional<PositiveLength> interval = s2plength(data.grid_interval);
   if (interval && (*interval != mBoard.getGridInterval())) {
+    if (mScene) {
+      mScene->setGridInterval(mBoard.getGridInterval());
+    }
     mBoard.setGridInterval(*interval);
     mProjectEditor.setManualModificationsMade();
-  }
-  if (mScene) {
-    mScene->setGridStyle(mGridStyle);
-    mScene->setGridInterval(mBoard.getGridInterval());
   }
   const LengthUnit unit = s2l(data.unit);
   if (unit != mBoard.getGridUnit()) {
@@ -2810,8 +2816,8 @@ FilePath Board2dTab::getBackgroundImageCacheDir() const noexcept {
 }
 
 void Board2dTab::applyWorkspaceSettings() noexcept {
-  const ColorScheme& scheme =
-      mApp.getWorkspace().getSettings().boardColorSchemes.getActive();
+  const WorkspaceSettings& settings = mApp.getWorkspace().getSettings();
+  const ColorScheme& scheme = settings.boardColorSchemes.getActive();
 
   if (mScene) {
     const auto background = scheme.getColors(ColorRole::boardBackground());
@@ -2820,7 +2826,7 @@ void Board2dTab::applyWorkspaceSettings() noexcept {
     mScene->setOverlayColors(overlay.primary, overlay.secondary);
     const auto selection = scheme.getColors(ColorRole::boardSelection());
     mScene->setSelectionRectColors(selection.primary, selection.secondary);
-    mScene->setGridStyle(mGridStyle);
+    mScene->setGridStyle(settings.boardGridStyle.get());
   }
 
   if (mUnplacedComponentGraphicsScene) {

--- a/libs/librepcb/editor/project/board/board2dtab.h
+++ b/libs/librepcb/editor/project/board/board2dtab.h
@@ -270,7 +270,6 @@ private:
   // State
   std::shared_ptr<BoardGraphicsScene::Context> mSceneContext;
   SearchContext mSearchContext;
-  GridStyle mGridStyle;
   QPointF mSceneImagePos;
   bool mIgnorePlacementLocks;
   int mFrameIndex;

--- a/libs/librepcb/editor/project/schematic/schematictab.cpp
+++ b/libs/librepcb/editor/project/schematic/schematictab.cpp
@@ -133,7 +133,6 @@ SchematicTab::SchematicTab(GuiApplication& app, SchematicEditor& editor,
                                 this)),
     mMsgInstallLibraries(app.getWorkspace(), "EMPTY_SCHEMATIC_NO_LIBRARIES"),
     mMsgAddDrawingFrame(app.getWorkspace(), "EMPTY_SCHEMATIC_ADD_FRAME"),
-    mGridStyle(mApp.getWorkspace().getSettings().schematicGridStyle.get()),
     mIgnorePlacementLocks(false),
     mFrameIndex(0),
     mToolFeatures(),
@@ -223,11 +222,8 @@ SchematicTab::SchematicTab(GuiApplication& app, SchematicEditor& editor,
 
   // Apply workspace settings whenever they have been modified.
   connect(&mApp.getWorkspace().getSettings().schematicGridStyle,
-          &WorkspaceSettingsItem::edited, this, [this]() {
-            mGridStyle =
-                mApp.getWorkspace().getSettings().schematicGridStyle.get();
-            applyWorkspaceSettings();
-          });
+          &WorkspaceSettingsItem::edited, this,
+          &SchematicTab::applyWorkspaceSettings);
   connect(&mApp.getWorkspace().getSettings().schematicColorSchemes,
           &WorkspaceSettingsItem_ColorSchemes::colorsModified, this,
           &SchematicTab::applyWorkspaceSettings);
@@ -316,7 +312,7 @@ ui::SchematicTabData SchematicTab::getDerivedUiData() const noexcept {
       q2s(fgColor),  // Foreground color
       q2s(infoBoxColors.primary),  // Overlay color
       q2s(infoBoxColors.secondary),  // Overlay text color
-      l2s(mGridStyle),  // Grid style
+      l2s(mApp.getWorkspace().getSettings().schematicGridStyle.get()),  // Grid
       l2s(*mSchematic.getGridInterval()),  // Grid interval
       l2s(mSchematic.getGridUnit()),  // Length unit
       mPinNumbersLayer && mPinNumbersLayer->isVisible(),  // Show pin numbers
@@ -367,15 +363,24 @@ ui::SchematicTabData SchematicTab::getDerivedUiData() const noexcept {
 void SchematicTab::setDerivedUiData(const ui::SchematicTabData& data) noexcept {
   mSceneImagePos = s2q(data.scene_image_pos);
 
-  mGridStyle = s2l(data.grid_style);
+  const GridStyle gridStyle = s2l(data.grid_style);
+  if (gridStyle != mApp.getWorkspace().getSettings().schematicGridStyle.get()) {
+    // Grid style setting used to be per-tab, but that is annoying for the
+    // use-case of temporarily hiding the grid for presenting a schematic to
+    // other people or for taking screenshots, since this has to be done for
+    // each tab again. Also it can be surprising that this UI setting is not
+    // persistent. It is probably much more intuitive to apply this setting
+    // to all tabs immediately, and storing it in the workspace settings.
+    mApp.getWorkspace().getSettings().schematicGridStyle.set(gridStyle);
+    mApp.scheduleWorkspaceSettingsSave();
+  }
   const std::optional<PositiveLength> interval = s2plength(data.grid_interval);
   if (interval && (*interval != mSchematic.getGridInterval())) {
+    if (mScene) {
+      mScene->setGridInterval(mSchematic.getGridInterval());
+    }
     mSchematic.setGridInterval(*interval);
     mProjectEditor.setManualModificationsMade();
-  }
-  if (mScene) {
-    mScene->setGridStyle(mGridStyle);
-    mScene->setGridInterval(mSchematic.getGridInterval());
   }
   const LengthUnit unit = s2l(data.unit);
   if (unit != mSchematic.getGridUnit()) {
@@ -1348,8 +1353,8 @@ void SchematicTab::goToObjects(
 }
 
 void SchematicTab::applyWorkspaceSettings() noexcept {
-  const ColorScheme& scheme =
-      mApp.getWorkspace().getSettings().schematicColorSchemes.getActive();
+  const WorkspaceSettings& settings = mApp.getWorkspace().getSettings();
+  const ColorScheme& scheme = settings.schematicColorSchemes.getActive();
 
   if (mScene) {
     const auto background = scheme.getColors(ColorRole::schematicBackground());
@@ -1358,7 +1363,7 @@ void SchematicTab::applyWorkspaceSettings() noexcept {
     mScene->setOverlayColors(overlay.primary, overlay.secondary);
     const auto selection = scheme.getColors(ColorRole::schematicSelection());
     mScene->setSelectionRectColors(selection.primary, selection.secondary);
-    mScene->setGridStyle(mGridStyle);
+    mScene->setGridStyle(settings.schematicGridStyle.get());
   }
 
   onDerivedUiDataChanged.notify();

--- a/libs/librepcb/editor/project/schematic/schematictab.h
+++ b/libs/librepcb/editor/project/schematic/schematictab.h
@@ -192,7 +192,6 @@ private:
 
   // State
   SearchContext mSearchContext;
-  GridStyle mGridStyle;
   QPointF mSceneImagePos;
   bool mIgnorePlacementLocks;
   int mFrameIndex;


### PR DESCRIPTION
Grid style setting used to be per-tab, but that is annoying for the use-case of temporarily hiding the grid for presenting a schematic to other people or for taking screenshots, since this has to be done for each tab again. Also it can be surprising that this UI setting is not persistent.

It is probably much more intuitive to apply this setting to all tabs immediately, and storing it in the workspace settings. So the grid style button in the status bar is now just linked to the corresponding workspace setting.