### PR TITLE
 Schematic editor: Merge collinear netlines after dragging 

### DIFF
--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
@@ -29,6 +29,7 @@
 #include "../../project/cmd/cmdschematicbuslabeledit.h"
 #include "../../project/cmd/cmdschematicnetlabeledit.h"
 #include "../../project/cmd/cmdschematicnetpointedit.h"
+#include "../../project/cmd/cmdsimplifyschematicsegments.h"
 #include "../../project/cmd/cmdsymbolinstanceedit.h"
 #include "../../project/cmd/cmdsymbolinstancetextsreset.h"
 #include "../schematic/schematicgraphicsscene.h"
@@ -37,10 +38,13 @@
 #include <librepcb/core/project/project.h>
 #include <librepcb/core/project/schematic/items/si_busjunction.h>
 #include <librepcb/core/project/schematic/items/si_buslabel.h>
+#include <librepcb/core/project/schematic/items/si_busline.h>
+#include <librepcb/core/project/schematic/items/si_bussegment.h>
 #include <librepcb/core/project/schematic/items/si_image.h>
 #include <librepcb/core/project/schematic/items/si_netlabel.h>
 #include <librepcb/core/project/schematic/items/si_netline.h>
 #include <librepcb/core/project/schematic/items/si_netpoint.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
 #include <librepcb/core/project/schematic/items/si_polygon.h>
 #include <librepcb/core/project/schematic/items/si_symbol.h>
 #include <librepcb/core/project/schematic/items/si_symbolpin.h>
@@ -86,6 +90,29 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
   query.addSelectedImages();
   query.addJunctionsOfBusLines();
   query.addNetPointsOfNetLines();
+
+  // Remember all segments whose geometry is affected by the drag. For symbols,
+  // the connected net lines are not part of the selection query, so collect
+  // their segments explicitly through the pins.
+  for (SI_BusLine* line : query.getBusLines()) {
+    mBusSegmentsToSimplify.insert(&line->getBusSegment());
+  }
+  for (SI_BusJunction* junction : query.getBusJunctions()) {
+    mBusSegmentsToSimplify.insert(&junction->getBusSegment());
+  }
+  for (SI_NetLine* line : query.getNetLines()) {
+    mNetSegmentsToSimplify.insert(&line->getNetSegment());
+  }
+  for (SI_NetPoint* point : query.getNetPoints()) {
+    mNetSegmentsToSimplify.insert(&point->getNetSegment());
+  }
+  for (SI_Symbol* symbol : query.getSymbols()) {
+    for (SI_SymbolPin* pin : symbol->getPins()) {
+      for (SI_NetLine* line : pin->getNetLines()) {
+        mNetSegmentsToSimplify.insert(&line->getNetSegment());
+      }
+    }
+  }
 
   // Find the center of all elements and create undo commands.
   foreach (SI_Symbol* symbol, query.getSymbols()) {
@@ -302,8 +329,9 @@ void CmdDragSelectedSchematicItems::mirror(
  ******************************************************************************/
 
 bool CmdDragSelectedSchematicItems::performExecute() {
-  if (mDeltaPos.isOrigin() && (mDeltaAngle == Angle::deg0()) &&
-      (!mSnappedToGrid) && (!mMirrored) && (!mTextsReset)) {
+  const bool geometryChanged = (!mDeltaPos.isOrigin()) ||
+      (mDeltaAngle != Angle::deg0()) || mSnappedToGrid || mMirrored;
+  if ((!geometryChanged) && (!mTextsReset)) {
     // no movement required --> discard all move commands
     qDeleteAll(mSymbolEditCmds);
     mSymbolEditCmds.clear();
@@ -357,6 +385,12 @@ bool CmdDragSelectedSchematicItems::performExecute() {
   }
   foreach (CmdImageEdit* cmd, mImageEditCmds) {
     appendChild(cmd);  // can throw
+  }
+  if (geometryChanged &&
+      ((!mNetSegmentsToSimplify.isEmpty()) ||
+       (!mBusSegmentsToSimplify.isEmpty()))) {
+    appendChild(new CmdSimplifySchematicSegments(
+        mNetSegmentsToSimplify, mBusSegmentsToSimplify));  // can throw
   }
 
   // execute all child commands

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
@@ -29,7 +29,6 @@
 #include "../../project/cmd/cmdschematicbuslabeledit.h"
 #include "../../project/cmd/cmdschematicnetlabeledit.h"
 #include "../../project/cmd/cmdschematicnetpointedit.h"
-#include "../../project/cmd/cmdsimplifyschematicsegments.h"
 #include "../../project/cmd/cmdsymbolinstanceedit.h"
 #include "../../project/cmd/cmdsymbolinstancetextsreset.h"
 #include "../schematic/schematicgraphicsscene.h"
@@ -329,9 +328,8 @@ void CmdDragSelectedSchematicItems::mirror(
  ******************************************************************************/
 
 bool CmdDragSelectedSchematicItems::performExecute() {
-  const bool geometryChanged = (!mDeltaPos.isOrigin()) ||
-      (mDeltaAngle != Angle::deg0()) || mSnappedToGrid || mMirrored;
-  if ((!geometryChanged) && (!mTextsReset)) {
+  if (mDeltaPos.isOrigin() && (mDeltaAngle == Angle::deg0()) &&
+      (!mSnappedToGrid) && (!mMirrored) && (!mTextsReset)) {
     // no movement required --> discard all move commands
     qDeleteAll(mSymbolEditCmds);
     mSymbolEditCmds.clear();
@@ -386,13 +384,6 @@ bool CmdDragSelectedSchematicItems::performExecute() {
   foreach (CmdImageEdit* cmd, mImageEditCmds) {
     appendChild(cmd);  // can throw
   }
-  if (geometryChanged &&
-      ((!mNetSegmentsToSimplify.isEmpty()) ||
-       (!mBusSegmentsToSimplify.isEmpty()))) {
-    appendChild(new CmdSimplifySchematicSegments(
-        mNetSegmentsToSimplify, mBusSegmentsToSimplify));  // can throw
-  }
-
   // execute all child commands
   return UndoCommandGroup::performExecute();  // can throw
 }

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.cpp
@@ -94,21 +94,21 @@ CmdDragSelectedSchematicItems::CmdDragSelectedSchematicItems(
   // the connected net lines are not part of the selection query, so collect
   // their segments explicitly through the pins.
   for (SI_BusLine* line : query.getBusLines()) {
-    mBusSegmentsToSimplify.insert(&line->getBusSegment());
+    mModifiedBusSegments.insert(&line->getBusSegment());
   }
   for (SI_BusJunction* junction : query.getBusJunctions()) {
-    mBusSegmentsToSimplify.insert(&junction->getBusSegment());
+    mModifiedBusSegments.insert(&junction->getBusSegment());
   }
   for (SI_NetLine* line : query.getNetLines()) {
-    mNetSegmentsToSimplify.insert(&line->getNetSegment());
+    mModifiedNetSegments.insert(&line->getNetSegment());
   }
   for (SI_NetPoint* point : query.getNetPoints()) {
-    mNetSegmentsToSimplify.insert(&point->getNetSegment());
+    mModifiedNetSegments.insert(&point->getNetSegment());
   }
   for (SI_Symbol* symbol : query.getSymbols()) {
     for (SI_SymbolPin* pin : symbol->getPins()) {
-      for (SI_NetLine* line : pin->getNetLines()) {
-        mNetSegmentsToSimplify.insert(&line->getNetSegment());
+      if (SI_NetSegment* segment = pin->getNetSegmentOfLines()) {
+        mModifiedNetSegments.insert(segment);
       }
     }
   }

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
@@ -35,6 +35,8 @@
  ******************************************************************************/
 namespace librepcb {
 
+class SI_BusSegment;
+class SI_NetSegment;
 class Schematic;
 
 namespace editor {
@@ -90,6 +92,10 @@ private:
   bool mSnappedToGrid;
   bool mMirrored;
   bool mTextsReset;
+
+  // Segments which might need to be simplified after moving their geometry.
+  QSet<SI_NetSegment*> mNetSegmentsToSimplify;
+  QSet<SI_BusSegment*> mBusSegmentsToSimplify;
 
   // Move commands
   QList<CmdSymbolInstanceEdit*> mSymbolEditCmds;

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
@@ -73,10 +73,10 @@ public:
   void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
   void mirror(Qt::Orientation orientation, bool aroundCurrentPosition) noexcept;
   const QSet<SI_NetSegment*>& getModifiedNetSegments() const noexcept {
-    return mNetSegmentsToSimplify;
+    return mModifiedNetSegments;
   }
   const QSet<SI_BusSegment*>& getModifiedBusSegments() const noexcept {
-    return mBusSegmentsToSimplify;
+    return mModifiedBusSegments;
   }
 
 private:
@@ -99,9 +99,9 @@ private:
   bool mMirrored;
   bool mTextsReset;
 
-  // Segments which might need to be simplified after moving their geometry.
-  QSet<SI_NetSegment*> mNetSegmentsToSimplify;
-  QSet<SI_BusSegment*> mBusSegmentsToSimplify;
+  // Segments whose geometry might have been modified by the drag.
+  QSet<SI_NetSegment*> mModifiedNetSegments;
+  QSet<SI_BusSegment*> mModifiedBusSegments;
 
   // Move commands
   QList<CmdSymbolInstanceEdit*> mSymbolEditCmds;

--- a/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedschematicitems.h
@@ -72,6 +72,12 @@ public:
   void setCurrentPosition(const Point& pos) noexcept;
   void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
   void mirror(Qt::Orientation orientation, bool aroundCurrentPosition) noexcept;
+  const QSet<SI_NetSegment*>& getModifiedNetSegments() const noexcept {
+    return mNetSegmentsToSimplify;
+  }
+  const QSet<SI_BusSegment*>& getModifiedBusSegments() const noexcept {
+    return mBusSegmentsToSimplify;
+  }
 
 private:
   // Private Methods

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
@@ -520,7 +520,15 @@ bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
     Q_ASSERT(mSelectedItemsDragCommand);
     mSelectedItemsDragCommand->setCurrentPosition(e.scenePos);
     try {
-      execCmd(mSelectedItemsDragCommand.release());  // can throw
+      const QSet<SI_NetSegment*> netSegments =
+          mSelectedItemsDragCommand->getModifiedNetSegments();
+      const QSet<SI_BusSegment*> busSegments =
+          mSelectedItemsDragCommand->getModifiedBusSegments();
+      if (execCmd(mSelectedItemsDragCommand.release()) &&
+          ((!netSegments.isEmpty()) || (!busSegments.isEmpty()))) {
+        execCmd(new CmdSimplifySchematicSegments(netSegments,
+                                                 busSegments));  // can throw
+      }
     } catch (const Exception& e) {
       QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());
     }

--- a/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
+++ b/libs/librepcb/editor/project/schematic/fsm/schematiceditorstate_select.cpp
@@ -526,8 +526,12 @@ bool SchematicEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
           mSelectedItemsDragCommand->getModifiedBusSegments();
       if (execCmd(mSelectedItemsDragCommand.release()) &&
           ((!netSegments.isEmpty()) || (!busSegments.isEmpty()))) {
-        execCmd(new CmdSimplifySchematicSegments(netSegments,
-                                                 busSegments));  // can throw
+        try {
+          execCmd(new CmdSimplifySchematicSegments(netSegments,
+                                                   busSegments));  // can throw
+        } catch (const Exception& e) {
+          qCritical() << "Failed to simplify schematic segments:" << e.getMsg();
+        }
       }
     } catch (const Exception& e) {
       QMessageBox::critical(parentWidget(), tr("Error"), e.getMsg());

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(
   editor/project/addcomponentdialogtest.cpp
   editor/project/board/boardclipboarddatatest.cpp
   editor/project/board/cmdboardspecctraimporttest.cpp
+  editor/project/schematic/cmddragselectedschematicitemstest.cpp
   editor/project/schematic/schematicclipboarddatatest.cpp
   editor/utils/shortcutsreferencegeneratortest.cpp
   editor/utils/slinthelperstest.cpp

--- a/tests/unittests/editor/project/schematic/cmddragselectedschematicitemstest.cpp
+++ b/tests/unittests/editor/project/schematic/cmddragselectedschematicitemstest.cpp
@@ -34,6 +34,7 @@
 #include <librepcb/core/project/schematic/schematic.h>
 #include <librepcb/editor/graphics/graphicslayerlist.h>
 #include <librepcb/editor/project/cmd/cmddragselectedschematicitems.h>
+#include <librepcb/editor/project/cmd/cmdsimplifyschematicsegments.h>
 #include <librepcb/editor/project/projectcrossprobe.h>
 #include <librepcb/editor/project/schematic/graphicsitems/sgi_netline.h>
 #include <librepcb/editor/project/schematic/schematicgraphicsscene.h>
@@ -98,7 +99,11 @@ TEST(CmdDragSelectedSchematicItemsTest, testMergeCollinearNetLines) {
   UndoStack undoStack;
   auto cmd = new CmdDragSelectedSchematicItems(scene);
   cmd->setCurrentPosition(Point(0, -2540000));
+  const QSet<SI_NetSegment*> netSegments = cmd->getModifiedNetSegments();
+  const QSet<SI_BusSegment*> busSegments = cmd->getModifiedBusSegments();
   EXPECT_TRUE(undoStack.execCmd(cmd));
+  EXPECT_TRUE(undoStack.execCmd(
+      new CmdSimplifySchematicSegments(netSegments, busSegments)));
 
   // The moved lines are collinear and therefore merged into a single line.
   SI_NetSegment* result = schematic.getNetSegments().value(segmentUuid);
@@ -111,14 +116,23 @@ TEST(CmdDragSelectedSchematicItemsTest, testMergeCollinearNetLines) {
               ((line->getP1().getPosition() == Point(5080000, 0)) &&
                (line->getP2().getPosition() == Point(0, 0))));
 
-  // Simplification is part of the drag command and follows its undo/redo.
+  // Simplification is a separate undo step, restoring the moved split lines.
   undoStack.undo();
   result = schematic.getNetSegments().value(segmentUuid);
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(3, result->getNetPoints().count());
   EXPECT_EQ(2, result->getNetLines().count());
+  EXPECT_EQ(Point(0, 0), p0->getPosition());
+  EXPECT_EQ(Point(2540000, 0), p1->getPosition());
+
+  // A second undo restores the drag itself.
+  undoStack.undo();
   EXPECT_EQ(Point(0, 2540000), p0->getPosition());
   EXPECT_EQ(Point(2540000, 2540000), p1->getPosition());
+
+  undoStack.redo();
+  EXPECT_EQ(Point(0, 0), p0->getPosition());
+  EXPECT_EQ(Point(2540000, 0), p1->getPosition());
 
   undoStack.redo();
   result = schematic.getNetSegments().value(segmentUuid);

--- a/tests/unittests/editor/project/schematic/cmddragselectedschematicitemstest.cpp
+++ b/tests/unittests/editor/project/schematic/cmddragselectedschematicitemstest.cpp
@@ -1,0 +1,136 @@
+/*
+ * LibrePCB - Professional EDA for everyone!
+ * Copyright (C) 2013 LibrePCB Developers, see AUTHORS.md for contributors.
+ * https://librepcb.org/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ *  Includes
+ ******************************************************************************/
+#include <gtest/gtest.h>
+#include <librepcb/core/fileio/transactionaldirectory.h>
+#include <librepcb/core/fileio/transactionalfilesystem.h>
+#include <librepcb/core/project/circuit/circuit.h>
+#include <librepcb/core/project/circuit/netclass.h>
+#include <librepcb/core/project/circuit/netsignal.h>
+#include <librepcb/core/project/project.h>
+#include <librepcb/core/project/projectloader.h>
+#include <librepcb/core/project/schematic/items/si_netline.h>
+#include <librepcb/core/project/schematic/items/si_netpoint.h>
+#include <librepcb/core/project/schematic/items/si_netsegment.h>
+#include <librepcb/core/project/schematic/schematic.h>
+#include <librepcb/editor/graphics/graphicslayerlist.h>
+#include <librepcb/editor/project/cmd/cmddragselectedschematicitems.h>
+#include <librepcb/editor/project/projectcrossprobe.h>
+#include <librepcb/editor/project/schematic/graphicsitems/sgi_netline.h>
+#include <librepcb/editor/project/schematic/schematicgraphicsscene.h>
+#include <librepcb/editor/undostack.h>
+
+#include <QtCore>
+
+#include <memory>
+
+/*******************************************************************************
+ *  Namespace
+ ******************************************************************************/
+namespace librepcb {
+namespace editor {
+namespace tests {
+
+/*******************************************************************************
+ *  Test Methods
+ ******************************************************************************/
+
+TEST(CmdDragSelectedSchematicItemsTest, testMergeCollinearNetLines) {
+  // Load an empty project and add a bent net consisting of two lines.
+  const FilePath projectFile(TEST_DATA_DIR
+                             "/projects/Empty Project/Empty Project.lpp");
+  const auto fileSystem =
+      TransactionalFileSystem::openRO(projectFile.getParentDir());
+  ProjectLoader loader;
+  std::unique_ptr<Project> project =
+      loader.open(std::make_unique<TransactionalDirectory>(fileSystem),
+                  projectFile.getFilename());
+  Schematic& schematic = *project->getSchematics().first();
+  Circuit& circuit = project->getCircuit();
+  auto netSignal = new NetSignal(circuit, Uuid::createRandom(),
+                                 *circuit.getNetClasses().first(),
+                                 CircuitIdentifier("N"), false);
+  netSignal->addToCircuit();
+
+  const Uuid segmentUuid = Uuid::createRandom();
+  auto segment = new SI_NetSegment(schematic, segmentUuid, *netSignal);
+  auto p0 = new SI_NetPoint(*segment, Uuid::createRandom(), Point(0, 2540000));
+  auto p1 =
+      new SI_NetPoint(*segment, Uuid::createRandom(), Point(2540000, 2540000));
+  auto p2 = new SI_NetPoint(*segment, Uuid::createRandom(), Point(5080000, 0));
+  auto l0 = new SI_NetLine(*segment, Uuid::createRandom(), *p0, *p1,
+                           SI_NetLine::getDefaultWidth());
+  auto l1 = new SI_NetLine(*segment, Uuid::createRandom(), *p1, *p2,
+                           SI_NetLine::getDefaultWidth());
+  segment->addNetPointsAndNetLines({p0, p1, p2}, {l0, l1});
+  schematic.addNetSegment(*segment);
+
+  // Select and move the horizontal line down to align it with the other line.
+  auto layers = GraphicsLayerList::schematicLayers(nullptr);
+  auto crossProbe = std::make_shared<ProjectCrossProbe>();
+  bool ignorePlacementLocks = false;
+  auto context = std::make_shared<SchematicGraphicsScene::Context>(
+      SchematicGraphicsScene::Context{nullptr, crossProbe,
+                                      GraphicsLayer::State::Enabled,
+                                      ignorePlacementLocks});
+  SchematicGraphicsScene scene(schematic, *layers, context);
+  scene.getNetLines().value(l0)->setSelected(true);
+
+  UndoStack undoStack;
+  auto cmd = new CmdDragSelectedSchematicItems(scene);
+  cmd->setCurrentPosition(Point(0, -2540000));
+  EXPECT_TRUE(undoStack.execCmd(cmd));
+
+  // The moved lines are collinear and therefore merged into a single line.
+  SI_NetSegment* result = schematic.getNetSegments().value(segmentUuid);
+  ASSERT_NE(nullptr, result);
+  EXPECT_EQ(2, result->getNetPoints().count());
+  ASSERT_EQ(1, result->getNetLines().count());
+  const SI_NetLine* line = result->getNetLines().first();
+  EXPECT_TRUE(((line->getP1().getPosition() == Point(0, 0)) &&
+               (line->getP2().getPosition() == Point(5080000, 0))) ||
+              ((line->getP1().getPosition() == Point(5080000, 0)) &&
+               (line->getP2().getPosition() == Point(0, 0))));
+
+  // Simplification is part of the drag command and follows its undo/redo.
+  undoStack.undo();
+  result = schematic.getNetSegments().value(segmentUuid);
+  ASSERT_NE(nullptr, result);
+  EXPECT_EQ(3, result->getNetPoints().count());
+  EXPECT_EQ(2, result->getNetLines().count());
+  EXPECT_EQ(Point(0, 2540000), p0->getPosition());
+  EXPECT_EQ(Point(2540000, 2540000), p1->getPosition());
+
+  undoStack.redo();
+  result = schematic.getNetSegments().value(segmentUuid);
+  ASSERT_NE(nullptr, result);
+  EXPECT_EQ(2, result->getNetPoints().count());
+  EXPECT_EQ(1, result->getNetLines().count());
+}
+
+/*******************************************************************************
+ *  End of File
+ ******************************************************************************/
+
+}  // namespace tests
+}  // namespace editor
+}  // namespace librepcb

--- a/tests/unittests/editor/project/schematic/cmddragselectedschematicitemstest.cpp
+++ b/tests/unittests/editor/project/schematic/cmddragselectedschematicitemstest.cpp
@@ -70,7 +70,7 @@ TEST(CmdDragSelectedSchematicItemsTest, testMergeCollinearNetLines) {
   auto netSignal = new NetSignal(circuit, Uuid::createRandom(),
                                  *circuit.getNetClasses().first(),
                                  CircuitIdentifier("N"), false);
-  netSignal->addToCircuit();
+  circuit.addNetSignal(*netSignal);
 
   const Uuid segmentUuid = Uuid::createRandom();
   auto segment = new SI_NetSegment(schematic, segmentUuid, *netSignal);


### PR DESCRIPTION
## Description

Automatically simplify affected schematic net and bus segments after dragging components, wires, or junctions. LibrePCB already had code capable of merging collinear wire segments: `CmdSimplifySchematicSegments`. The missing part was calling it after dragging.

Moving a component or wire could previously leave directly connected collinear netlines as separate internal objects. Although these lines appeared as one continuous wire, later editing operations could produce overlapping or unexpected wire geometry.

The drag command now collects the affected segments before movement. Once the drag has been committed on mouse release, the existing schematic segment simplification command is pushed onto the undo stack as a separate action.

Segments connected to moved component pins are included explicitly because their netlines are not part of the selection query. Label-only moves do not trigger simplification.

Keeping both operations separate provides the following undo/redo behavior:

- The first undo reverses simplification while keeping the dragged geometry. 
- The second undo reverses the drag.
- Redo reapplies the drag first and simplification second.

Fixes #1823.

https://github.com/user-attachments/assets/6fd49f87-8a71-420c-9e6a-2b5fb4741bfc

## Testing

- Added a regression test covering collinear netline merging after dragging.
- Verified that the first undo restores the moved, split netlines.
- Verified that the second undo restores the original drag position.
- Verified the corresponding two-step redo behavior.
- Passed all executed unit tests.
- One unrelated UI tab-order test was skipped.
- Passed the project formatting check.
- Successfully built the LibrePCB application.