### PR TITLE
CLI: Run headless without requiring an X server

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,7 +123,7 @@ jobs:
         run: xvfb-run -a ./build/tests/unittests/librepcb-unittests
         if: ${{ (steps.build.outcome == 'success') && (!cancelled()) }}
       - name: Run LibrePCB-CLI Functional Tests
-        run: xvfb-run -a --server-args="-screen 0 1024x768x24" uv --directory ./tests/cli run --no-dev pytest -vvv --librepcb-executable="../../build/install/bin/librepcb-cli"
+        run: uv --directory ./tests/cli run --no-dev pytest -vvv --librepcb-executable="../../build/install/bin/librepcb-cli"
         if: ${{ (steps.build.outcome == 'success') && (!cancelled()) }}
       - name: Run LibrePCB Functional Tests
         run: xvfb-run -a --server-args="-screen 0 1024x768x24" uv --directory ./tests/funq run --no-dev pytest -vvv --librepcb-executable="../../build/install/bin/librepcb" --reruns 5 --reruns-delay 10

--- a/apps/librepcb-cli/main.cpp
+++ b/apps/librepcb-cli/main.cpp
@@ -47,6 +47,16 @@ int main(int argc, char* argv[]) {
   // Creates the Debug object which installs the message handler. This must be
   // done as early as possible.
   Debug::instance();
+  
+#ifdef Q_OS_LINUX
+  // Avoid requiring a real X server / Xvfb just to run the CLI headlessly.
+  // "offscreen" works fine for our PDF/image/gerber export (unlike
+  // "minimal", which doesn't actually render anything). Don't override if
+  // the user already set QT_QPA_PLATFORM themselves.
+  if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+  }
+#endif
 
   // Silence logging output, it's a command line tool where logging messages
   // could lead to issues when parsing the CLI output. Real errors will be

--- a/apps/librepcb-cli/main.cpp
+++ b/apps/librepcb-cli/main.cpp
@@ -47,13 +47,15 @@ int main(int argc, char* argv[]) {
   // Creates the Debug object which installs the message handler. This must be
   // done as early as possible.
   Debug::instance();
-  
+
 #ifdef Q_OS_LINUX
-  // Avoid requiring a real X server / Xvfb just to run the CLI headlessly.
-  // "offscreen" works fine for our PDF/image/gerber export (unlike
-  // "minimal", which doesn't actually render anything). Don't override if
-  // the user already set QT_QPA_PLATFORM themselves.
-  if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+  // Only force offscreen rendering if there's truly no display available
+  // and the user hasn't picked a platform themselves. This keeps existing
+  // setups working (e.g. CI running under xvfb-run) and only kicks in for
+  // genuinely headless environments.
+  if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM") &&
+      qEnvironmentVariableIsEmpty("DISPLAY") &&
+      qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY")) {
     qputenv("QT_QPA_PLATFORM", "offscreen");
   }
 #endif

--- a/ci/build_linux_portables.sh
+++ b/ci/build_linux_portables.sh
@@ -23,6 +23,10 @@ mv "./build/install" "./build/AppDir/usr"
 # Expand LD_LIBRARY_PATH to allow linuxdeploy finding liblibrepcbslint.so.
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:`pwd`/build/AppDir/usr/lib"
 
+# Bundle the offscreen platform plugin too, so librepcb-cli can run
+# without a display (X11) available, see issue #1793 for details.
+export EXTRA_PLATFORM_PLUGINS="libqoffscreen.so"
+
 # Build AppImage, which will also make the AppDir portable.
 # Specify OpenSSL libraries manually since these runtime dependencies cannot
 # be detected by linuxdeploy.
@@ -38,7 +42,7 @@ mv "./build/AppDir/usr" "./build/install"
 
 # Test if the bundles are working (hopefully catching deployment issues).
 # Doesn't work for AppImages unfortunately because of missing fuse on CI.
-xvfb-run -a ./build/install/bin/librepcb-cli --version
+./build/install/bin/librepcb-cli --version
 xvfb-run -a ./build/install/bin/librepcb --exit-after-startup
 
 # Print checksums to allow fully transparent public verification.


### PR DESCRIPTION
Fixes #1793.

librepcb-cli needs an X server on Linux right now because
QGuiApplication defaults to the "xcb" platform plugin. This forces
"offscreen" instead (unless QT_QPA_PLATFORM is already set), so the
CLI can run in Docker/CI without xvfb-run.

Went with "offscreen" rather than "minimal" as both were mentioned in
the issue, because the export commands do real rendering
(QPainter/QImage/QPrinter/QPdfWriter), and offscreen is the backend
meant for that. minimal is just a stub.

## Testing

Ubuntu 24.04, Qt 6.4.2.

Before, with no DISPLAY/WAYLAND_DISPLAY:

    ./librepcb-cli --version
    [FATAL] This application failed to start because no Qt platform
    plugin could be initialized.

After:

    ./librepcb-cli --version
    LibrePCB CLI Version ...

Also checked the export path itself, not just startup:

    ./librepcb-cli open-project tests/data/projects/DRC/project.lpp \
      --export-schematics /tmp/test.pdf

Produces a correct, non-empty PDF headlessly.

Also confirmed setting QT_QPA_PLATFORM manually still works (not
overridden), and normal desktop use with a display is unaffected.

The change is behind #ifdef Q_OS_LINUX, so it's a no-op on
macOS/Windows, CI should confirm nothing there changes.

Haven't touched the docker-librepcb-cli image yet, can follow up
with that separately once this lands, as the issue suggests.