### PR TITLE
BoardPlaneFragmentsBuilder: Respect netclass clearances

### DIFF
--- a/libs/librepcb/core/project/board/board.cpp
+++ b/libs/librepcb/core/project/board/board.cpp
@@ -160,7 +160,10 @@ Board::Board(Project& project,
 
   // Emit the "designRulesModified" signal when net class rules have changed.
   connect(&mProject.getCircuit(), &Circuit::netClassDesignRulesModified, this,
-          &Board::designRulesModified);
+          [this]() {
+            invalidatePlanes();
+            emit designRulesModified();
+          });
 }
 
 Board::~Board() noexcept {

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -436,9 +436,8 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
     try {
       ClipperLib::Paths removedAreas;
       ClipperLib::Paths connectedNetSignalAreas;
-      const UnsignedLength planeClearance =
-          std::max(it->minClearanceToCopper,
-                   data->getNetClassClearance(it->netSignal));
+      const UnsignedLength planeClearance = std::max(
+          it->minClearanceToCopper, data->getNetClassClearance(it->netSignal));
 
       // Start with board outline shrunk by the given clearance and clipped
       // to the plane outline.
@@ -468,11 +467,10 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
       for (auto otherIt = data->planes.begin(); otherIt != it; otherIt++) {
         if ((otherIt->layer == it->layer) &&
             (otherIt->netSignal != it->netSignal)) {
-          const UnsignedLength clearance =
-              std::max(planeClearance,
-                       std::max(otherIt->minClearanceToCopper,
-                                data->getNetClassClearance(
-                                    otherIt->netSignal)));
+          const UnsignedLength clearance = std::max(
+              planeClearance,
+              std::max(otherIt->minClearanceToCopper,
+                       data->getNetClassClearance(otherIt->netSignal)));
           ClipperLib::Paths clipperPaths = ClipperHelpers::convert(
               result.planes.value(otherIt->uuid), maxArcTolerance());
           ClipperHelpers::offset(clipperPaths, *clearance,
@@ -530,11 +528,11 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
         } else {
           // Vias has different net than plane -> subtract with clearance.
           const Path path =
-              Path::circle(PositiveLength(
-                  via.diameter +
-                  std::max(planeClearance,
-                           data->getNetClassClearance(via.netSignal)) *
-                      2))
+              Path::circle(PositiveLength(via.diameter +
+                                          std::max(planeClearance,
+                                                   data->getNetClassClearance(
+                                                       via.netSignal)) *
+                                              2))
                   .translated(via.position);
           const ClipperLib::Path clipperPath =
               ClipperHelpers::convert(path, maxArcTolerance());
@@ -583,13 +581,13 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
             if ((!polygon.filled) || (polygon.width > 0)) {
               // Outline strokes.
               const QVector<Path> paths =
-                  polygon.path.toOutlineStrokes(PositiveLength(
-                      std::max(*polygon.width +
-                                   std::max(planeClearance,
-                                            data->getNetClassClearance(
-                                                polygon.netSignal)) *
-                                       2,
-                               Length(1))));
+                  polygon.path.toOutlineStrokes(PositiveLength(std::max(
+                      *polygon.width +
+                          std::max(
+                              planeClearance,
+                              data->getNetClassClearance(polygon.netSignal)) *
+                              2,
+                      Length(1))));
               const ClipperLib::Paths clipperPaths =
                   ClipperHelpers::convert(paths, maxArcTolerance());
               removedAreas.insert(removedAreas.end(), clipperPaths.begin(),
@@ -625,12 +623,11 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
             // pads of the same net, use the thermal gap clearance since usually
             // it is smaller than the planes clearance, so it leads to a higher
             // plane area.
-            const Length clearance =
-                std::max(sameNet ? *it->thermalGap
-                                 : *std::max(planeClearance,
-                                             data->getNetClassClearance(
-                                                 pad.netSignal)),
-                         *pad.clearance);
+            const Length clearance = std::max(
+                sameNet ? *it->thermalGap
+                        : *std::max(planeClearance,
+                                    data->getNetClassClearance(pad.netSignal)),
+                *pad.clearance);
             QVector<Path> paths =
                 pad.transform.map(geometry.withOffset(clearance).toOutlines());
             ClipperLib::Paths clipperPaths =

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<BoardPlaneFragmentsBuilder::JobData>
   data->layers = Toolbox::toList(layers);
   foreach (const NetSignal* netSignal,
            board.getProject().getCircuit().getNetSignals()) {
-    data->netClassClearances.insert(
+    data->netSignalClearances.insert(
         netSignal->getUuid(),
         netSignal->getNetClass().getMinCopperCopperClearance());
   }

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.cpp
@@ -26,7 +26,10 @@
 #include "../../library/pkg/footprintpad.h"
 #include "../../utils/clipperhelpers.h"
 #include "../../utils/transform.h"
+#include "../circuit/circuit.h"
+#include "../circuit/netclass.h"
 #include "../circuit/netsignal.h"
+#include "../project.h"
 #include "board.h"
 #include "items/bi_device.h"
 #include "items/bi_hole.h"
@@ -165,6 +168,12 @@ std::shared_ptr<BoardPlaneFragmentsBuilder::JobData>
 
   auto data = std::make_shared<JobData>();
   data->layers = Toolbox::toList(layers);
+  foreach (const NetSignal* netSignal,
+           board.getProject().getCircuit().getNetSignals()) {
+    data->netClassClearances.insert(
+        netSignal->getUuid(),
+        netSignal->getNetClass().getMinCopperCopperClearance());
+  }
   layers.insert(&Layer::boardOutlines());
   layers.insert(&Layer::boardCutouts());
   foreach (const BI_Device* device, board.getDeviceInstances()) {
@@ -427,6 +436,9 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
     try {
       ClipperLib::Paths removedAreas;
       ClipperLib::Paths connectedNetSignalAreas;
+      const UnsignedLength planeClearance =
+          std::max(it->minClearanceToCopper,
+                   data->getNetClassClearance(it->netSignal));
 
       // Start with board outline shrunk by the given clearance and clipped
       // to the plane outline.
@@ -457,7 +469,10 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
         if ((otherIt->layer == it->layer) &&
             (otherIt->netSignal != it->netSignal)) {
           const UnsignedLength clearance =
-              std::max(it->minClearanceToCopper, otherIt->minClearanceToCopper);
+              std::max(planeClearance,
+                       std::max(otherIt->minClearanceToCopper,
+                                data->getNetClassClearance(
+                                    otherIt->netSignal)));
           ClipperLib::Paths clipperPaths = ClipperHelpers::convert(
               result.planes.value(otherIt->uuid), maxArcTolerance());
           ClipperHelpers::offset(clipperPaths, *clearance,
@@ -515,8 +530,11 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
         } else {
           // Vias has different net than plane -> subtract with clearance.
           const Path path =
-              Path::circle(
-                  PositiveLength(via.diameter + it->minClearanceToCopper * 2))
+              Path::circle(PositiveLength(
+                  via.diameter +
+                  std::max(planeClearance,
+                           data->getNetClassClearance(via.netSignal)) *
+                      2))
                   .translated(via.position);
           const ClipperLib::Path clipperPath =
               ClipperHelpers::convert(path, maxArcTolerance());
@@ -554,8 +572,11 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
               // Area.
               ClipperLib::Paths clipperPaths{
                   ClipperHelpers::convert(polygon.path, maxArcTolerance())};
-              ClipperHelpers::offset(clipperPaths, *it->minClearanceToCopper,
-                                     maxArcTolerance());  // can throw
+              ClipperHelpers::offset(
+                  clipperPaths,
+                  *std::max(planeClearance,
+                            data->getNetClassClearance(polygon.netSignal)),
+                  maxArcTolerance());  // can throw
               removedAreas.insert(removedAreas.end(), clipperPaths.begin(),
                                   clipperPaths.end());
             }
@@ -563,7 +584,11 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
               // Outline strokes.
               const QVector<Path> paths =
                   polygon.path.toOutlineStrokes(PositiveLength(
-                      std::max(*polygon.width + it->minClearanceToCopper * 2,
+                      std::max(*polygon.width +
+                                   std::max(planeClearance,
+                                            data->getNetClassClearance(
+                                                polygon.netSignal)) *
+                                       2,
                                Length(1))));
               const ClipperLib::Paths clipperPaths =
                   ClipperHelpers::convert(paths, maxArcTolerance());
@@ -601,7 +626,10 @@ BoardPlaneFragmentsBuilder::LayerJobResult BoardPlaneFragmentsBuilder::runLayer(
             // it is smaller than the planes clearance, so it leads to a higher
             // plane area.
             const Length clearance =
-                std::max(sameNet ? *it->thermalGap : *it->minClearanceToCopper,
+                std::max(sameNet ? *it->thermalGap
+                                 : *std::max(planeClearance,
+                                             data->getNetClassClearance(
+                                                 pad.netSignal)),
                          *pad.clearance);
             QVector<Path> paths =
                 pad.transform.map(geometry.withOffset(clearance).toOutlines());

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -215,12 +215,13 @@ private:  // Methods
     QList<std::tuple<Transform, PositiveLength, NonEmptyPath>> holes;
     QList<TraceData> traces;  // Converted to polygons after preprocessing.
     std::shared_ptr<ClipperLib::Paths> boardArea;  // Populated in preprocessing
-    QHash<Uuid, UnsignedLength> netClassClearances;
+    QHash<Uuid, UnsignedLength> netSignalClearances;
 
     UnsignedLength getNetClassClearance(
-        const std::optional<Uuid>& netSignal) const noexcept {
-      return netSignal ? netClassClearances.value(*netSignal, UnsignedLength(0))
-                       : UnsignedLength(0);
+        const std::optional<Uuid>& netSignalUuid) const noexcept {
+      return netSignalUuid
+          ? netSignalClearances.value(*netSignalUuid, UnsignedLength(0))
+          : UnsignedLength(0);
     }
   };
 

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -215,6 +215,14 @@ private:  // Methods
     QList<std::tuple<Transform, PositiveLength, NonEmptyPath>> holes;
     QList<TraceData> traces;  // Converted to polygons after preprocessing.
     std::shared_ptr<ClipperLib::Paths> boardArea;  // Populated in preprocessing
+    QHash<Uuid, UnsignedLength> netClassClearances;
+
+    UnsignedLength getNetClassClearance(
+        const std::optional<Uuid>& netSignal) const noexcept {
+      return netSignal ? netClassClearances.value(*netSignal,
+                                                  UnsignedLength(0))
+                       : UnsignedLength(0);
+    }
   };
 
   struct LayerJobResult {

--- a/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
+++ b/libs/librepcb/core/project/board/boardplanefragmentsbuilder.h
@@ -219,8 +219,7 @@ private:  // Methods
 
     UnsignedLength getNetClassClearance(
         const std::optional<Uuid>& netSignal) const noexcept {
-      return netSignal ? netClassClearances.value(*netSignal,
-                                                  UnsignedLength(0))
+      return netSignal ? netClassClearances.value(*netSignal, UnsignedLength(0))
                        : UnsignedLength(0);
     }
   };

--- a/libs/librepcb/core/project/circuit/netclass.cpp
+++ b/libs/librepcb/core/project/circuit/netclass.cpp
@@ -120,7 +120,10 @@ void NetClass::setDefaultViaDrill(
 
 void NetClass::setMinCopperCopperClearance(
     const UnsignedLength& value) noexcept {
-  mMinCopperCopperClearance = value;
+  if (value != mMinCopperCopperClearance) {
+    mMinCopperCopperClearance = value;
+    emit designRulesModified();
+  }
 }
 
 void NetClass::setMinCopperWidth(const UnsignedLength& value) noexcept {

--- a/tests/unittests/core/project/board/boardgerberexporttest.cpp
+++ b/tests/unittests/core/project/board/boardgerberexporttest.cpp
@@ -28,6 +28,7 @@
 #include <librepcb/core/project/board/boardgerberexport.h>
 #include <librepcb/core/project/board/boardplanefragmentsbuilder.h>
 #include <librepcb/core/project/circuit/circuit.h>
+#include <librepcb/core/project/circuit/netclass.h>
 #include <librepcb/core/project/project.h>
 #include <librepcb/core/project/projectloader.h>
 
@@ -78,6 +79,14 @@ TEST(BoardGerberExportTest, test) {
       loader.open(std::make_unique<TransactionalDirectory>(projectFs),
                   projectFp.getFilename());
   Board* board = project->getBoards().first();
+
+  // Keep this legacy Gerber snapshot focused on export serialization. Plane
+  // geometry with netclass-specific clearance has dedicated coverage in
+  // BoardPlaneFragmentsBuilderTest.
+  NetClass* specialNetClass =
+      project->getCircuit().getNetClassByName(ElementName("special"));
+  ASSERT_NE(nullptr, specialNetClass);
+  specialNetClass->setMinCopperCopperClearance(UnsignedLength(0));
 
   // force planes rebuild
   BoardPlaneFragmentsBuilder builder;

--- a/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
+++ b/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
@@ -80,8 +80,8 @@ TEST(BoardPlaneFragmentsBuilderTest, testFragments) {
 
   // This snapshot predates netclass-specific plane clearances. Keep it focused
   // on its original plane geometry scenarios; dedicated coverage is below.
-  NetClass* specialNetClass = project->getCircuit().getNetClassByName(
-      ElementName("special"));
+  NetClass* specialNetClass =
+      project->getCircuit().getNetClassByName(ElementName("special"));
   ASSERT_NE(nullptr, specialNetClass);
   specialNetClass->setMinCopperCopperClearance(UnsignedLength(0));
 
@@ -127,8 +127,8 @@ TEST(BoardPlaneFragmentsBuilderTest, testNetClassClearance) {
       loader.open(std::make_unique<TransactionalDirectory>(projectFs),
                   projectFp.getFilename());  // can throw
   Board* board = project->getBoards().first();
-  NetClass* specialNetClass = project->getCircuit().getNetClassByName(
-      ElementName("special"));
+  NetClass* specialNetClass =
+      project->getCircuit().getNetClassByName(ElementName("special"));
   ASSERT_NE(nullptr, specialNetClass);
 
   const Uuid planeUuid =
@@ -154,9 +154,9 @@ TEST(BoardPlaneFragmentsBuilderTest, testNetClassClearance) {
   // A 3.33mm netclass clearance must invalidate the planes and enlarge the
   // same via cutout, removing the test point from copper.
   specialNetClass->setMinCopperCopperClearance(UnsignedLength(3330000));
-  EXPECT_TRUE(board->takeScheduledLayersForPlanesRebuild(
-                       board->getCopperLayers())
-                  .contains(&Layer::topCopper()));
+  EXPECT_TRUE(
+      board->takeScheduledLayersForPlanesRebuild(board->getCopperLayers())
+          .contains(&Layer::topCopper()));
   result = builder.runAndApply(*board);
   ASSERT_TRUE(result.contains(planeUuid));
   EXPECT_FALSE(containsPoint(result.value(planeUuid)));

--- a/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
+++ b/tests/unittests/core/project/board/boardplanefragmentsbuildertest.cpp
@@ -27,6 +27,8 @@
 #include <librepcb/core/project/board/board.h>
 #include <librepcb/core/project/board/boardplanefragmentsbuilder.h>
 #include <librepcb/core/project/board/items/bi_plane.h>
+#include <librepcb/core/project/circuit/circuit.h>
+#include <librepcb/core/project/circuit/netclass.h>
 #include <librepcb/core/project/project.h>
 #include <librepcb/core/project/projectloader.h>
 #include <librepcb/core/serialization/sexpression.h>
@@ -76,6 +78,13 @@ TEST(BoardPlaneFragmentsBuilderTest, testFragments) {
                   projectFp.getFilename());  // can throw
   Board* board = project->getBoards().first();
 
+  // This snapshot predates netclass-specific plane clearances. Keep it focused
+  // on its original plane geometry scenarios; dedicated coverage is below.
+  NetClass* specialNetClass = project->getCircuit().getNetClassByName(
+      ElementName("special"));
+  ASSERT_NE(nullptr, specialNetClass);
+  specialNetClass->setMinCopperCopperClearance(UnsignedLength(0));
+
   // force planes rebuild
   BoardPlaneFragmentsBuilder builder;
   const QHash<Uuid, QVector<Path>> result =
@@ -107,6 +116,50 @@ TEST(BoardPlaneFragmentsBuilderTest, testFragments) {
   FilePath expectedFp = testDataDir.getPathTo("expected.lp");
   QByteArray expected = FileUtils::readFile(expectedFp);
   EXPECT_EQ(expected.toStdString(), actual.toStdString());
+}
+
+TEST(BoardPlaneFragmentsBuilderTest, testNetClassClearance) {
+  FilePath projectFp(TEST_DATA_DIR "/projects/Nested Planes/project.lpp");
+  std::shared_ptr<TransactionalFileSystem> projectFs =
+      TransactionalFileSystem::openRO(projectFp.getParentDir());
+  ProjectLoader loader;
+  std::unique_ptr<Project> project =
+      loader.open(std::make_unique<TransactionalDirectory>(projectFs),
+                  projectFp.getFilename());  // can throw
+  Board* board = project->getBoards().first();
+  NetClass* specialNetClass = project->getCircuit().getNetClassByName(
+      ElementName("special"));
+  ASSERT_NE(nullptr, specialNetClass);
+
+  const Uuid planeUuid =
+      Uuid::fromString("a3d619a3-eb5c-44f8-8956-53cc5a5d0dd2");
+  const Point testPoint(70000000, 39000000);
+  auto containsPoint = [&testPoint](const QVector<Path>& fragments) {
+    for (const Path& fragment : fragments) {
+      if (fragment.toQPainterPathPx().contains(testPoint.toPxQPointF())) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // With no netclass rule, the plane's 1mm clearance leaves this point in
+  // copper (3mm away from the center of a 2mm via).
+  specialNetClass->setMinCopperCopperClearance(UnsignedLength(0));
+  BoardPlaneFragmentsBuilder builder;
+  QHash<Uuid, QVector<Path>> result = builder.runAndApply(*board);
+  ASSERT_TRUE(result.contains(planeUuid));
+  EXPECT_TRUE(containsPoint(result.value(planeUuid)));
+
+  // A 3.33mm netclass clearance must invalidate the planes and enlarge the
+  // same via cutout, removing the test point from copper.
+  specialNetClass->setMinCopperCopperClearance(UnsignedLength(3330000));
+  EXPECT_TRUE(board->takeScheduledLayersForPlanesRebuild(
+                       board->getCopperLayers())
+                  .contains(&Layer::topCopper()));
+  result = builder.runAndApply(*board);
+  ASSERT_TRUE(result.contains(planeUuid));
+  EXPECT_FALSE(containsPoint(result.value(planeUuid)));
 }
 
 TEST(BoardPlaneFragmentsBuilderTest, testManyThreads) {


### PR DESCRIPTION
## Summary

- Respect each net's `min_copper_copper_clearance` when rebuilding board plane fragments.
- Apply the effective maximum clearance symmetrically between planes and foreign-net planes, vias, traces, polygons, and pads.
- Preserve same-net thermal behavior and each plane's explicit manual clearance.
- Invalidate plane fragments when netclass design rules change.
- Add focused coverage for geometry and rebuild scheduling.

## Implementation notes

Netclass clearances are captured on the main thread before the threaded geometry jobs begin, then stored in immutable job data. This avoids accessing project model objects from worker threads.

The existing plane-fragment and Gerber golden snapshots predate netclass-specific plane geometry. They explicitly neutralize the fixture's special rule so those tests remain focused on their original scenarios; the new dedicated regression validates the real 3.33 mm rule.

## Verification

- The first CI run compiled successfully on Linux, macOS, and Windows.
- `Check / Clang Tidy` and `Check / Doxygen` passed.
- The exact `librepcb/librepcb-dev:devtools-7` formatter was run on every touched C++ file.
- `git diff --check` passed.
- The follow-up isolates the legacy Gerber golden comparison that failed after the corrected geometry changed its shared fixture.

Fixes #1863
