### PR TITLE
Add trace dragging and copper pad expansion settings

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -20,377 +20,69 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
+#include "./commandlineinterface.h"
+
 #include <librepcb/core/application.h>
 #include <librepcb/core/debug.h>
-#include <librepcb/core/exceptions.h>
-#include <librepcb/core/network/networkaccessmanager.h>
-#include <librepcb/core/workspace/uitheme.h>
-#include <librepcb/core/workspace/workspace.h>
-#include <librepcb/core/workspace/workspacesettings.h>
-#include <librepcb/editor/dialogs/directorylockhandlerdialog.h>
-#include <librepcb/editor/editorcommandset.h>
-#include <librepcb/editor/guiapplication.h>
-#include <librepcb/editor/project/partinformationprovider.h>
-#include <librepcb/editor/utils/editortoolbox.h>
-#include <librepcb/editor/utils/slinthelpers.h>
-#include <librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizard.h>
 
-#include <QtConcurrent>
 #include <QtCore>
-#include <QtWidgets>
+#include <QtGui>
 
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
 using namespace librepcb;
-using namespace librepcb::editor;
-
-/*******************************************************************************
- *  Global Data
- ******************************************************************************/
-
-static const UiTheme* sTheme = nullptr;
-
-/*******************************************************************************
- *  Function Prototypes
- ******************************************************************************/
-
-static void setApplicationMetadata() noexcept;
-static void configureApplicationSettings() noexcept;
-static void writeLogHeader() noexcept;
-static void setTheme(const QString& name) noexcept;
-static int runApplication() noexcept;
-static bool isFileFormatStableOrAcceptUnstable() noexcept;
-static int openWorkspace(FilePath& path);
 
 /*******************************************************************************
  *  main()
  ******************************************************************************/
 
 int main(int argc, char* argv[]) {
-  // Workaround for issues with libfreetype 2.14 (crash with older Qt versions,
-  // partially missing glyph rendering with Qt 6.11.1), see
-  // https://qt-project.atlassian.net/browse/QTBUG-145783. The problem occurred
-  // with small schematic texts (~<2mm) on relatively large zoom factors.
+  // From librepcb/main.cpp - not sure if we need this also in the CLI, but
+  // at least it shouldn't hurt.
   if (qEnvironmentVariableIsEmpty("QT_MAX_CACHED_GLYPH_SIZE")) {
     qputenv("QT_MAX_CACHED_GLYPH_SIZE", "32");
   }
 
-  QApplication app(argc, argv);
+  // Creates the Debug object which installs the message handler. This must be
+  // done as early as possible.
+  Debug::instance();
 
-  // Give the main thread a higher priority than most other threads as GUI
-  // rendering and event processing are important for a smooth user experience.
-  QThread::currentThread()->setPriority(QThread::HighPriority);
+#ifdef Q_OS_LINUX
+  // Only force offscreen rendering if there's truly no display available
+  // and the user hasn't picked a platform themselves. This keeps existing
+  // setups working (e.g. CI running under xvfb-run) and only kicks in for
+  // genuinely headless environments.
+  if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM") &&
+      qEnvironmentVariableIsEmpty("DISPLAY") &&
+      qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY")) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+  }
+#endif
+
+  // Silence logging output, it's a command line tool where logging messages
+  // could lead to issues when parsing the CLI output. Real errors will be
+  // printed to stderr explicitly and logging output can optionally be enabled
+  // with the "--verbose" flag. But still print fatal errors since this is the
+  // only way to print any error to stderr before the application gets aborted.
+  Debug::instance()->setDebugLevelStderr(Debug::DebugLevel_t::Fatal);
+
+  // Create Application instance
+  QGuiApplication app(argc, argv);
 
   // Set the organization / application names must be done very early because
   // some other classes will use these values (for example QSettings, Debug)!
-  setApplicationMetadata();
-
-  // Creates the Debug object which installs the message handler. This must be
-  // done as early as possible, but *after* setting application metadata
-  // (organization + name).
-  Debug::instance();
-
-  // Configure the application settings format and location used by QSettings
-  configureApplicationSettings();
-
-  // Write some information about the application instance to the log.
-  writeLogHeader();
+  QGuiApplication::setOrganizationName("LibrePCB");
+  QGuiApplication::setOrganizationDomain("librepcb.org");
+  QGuiApplication::setApplicationName("LibrePCB CLI");
+  QGuiApplication::setApplicationVersion(Application::getVersion());
 
   // Perform global initialization tasks. This must be done before any widget is
   // shown.
   Application::loadBundledFonts();
   Application::setTranslationLocale(QLocale::system());
-  std::ignore = EditorToolbox::isSystemThemeDark();
 
-  // Clean up old temporary files since at least on Windows this is not done
-  // automatically. Let's do it in a thread to avoid delaying application start.
-  std::ignore = QtConcurrent::run(&Application::cleanTemporaryDirectory);
-
-  // This is to remove the ugly frames around widgets in all status bars...
-  // (from http://www.qtcentre.org/threads/1904)
-  app.setStyleSheet("QStatusBar::item { border: 0px solid black; }");
-
-  // Use Fusion style with custom palette to make the legacy Qt dialogs looking
-  // similar to the new Slint UI. Can be removed as soon as no Qt widgets are
-  // used anymore. The actual palette will be set later.
-  app.setStyle("fusion");
-
-  // Apply default theme (will be overridden later if workspace settings are
-  // loaded).
-  setTheme(QString());
-
-  // Register our custom translator to Slint.
-  slint::set_translator(std::make_unique<SlintTranslator>());
-
-  // Start network access manager thread with HTTP cache to avoid extensive
-  // requests (e.g. downloading library pictures each time opening the manager).
-  QScopedPointer<NetworkAccessManager> networkAccessManager(
-      new NetworkAccessManager(Application::getCacheDir().getPathTo("http")));
-
-  // Run the actual application
-  int retval = runApplication();
-
-  // Stop network access manager thread
-  networkAccessManager.reset();
-
-  qDebug().nospace() << "Exit application with code " << retval << ".";
-  return retval;
-}
-
-/*******************************************************************************
- *  setApplicationMetadata()
- ******************************************************************************/
-
-static void setApplicationMetadata() noexcept {
-  QApplication::setOrganizationName("LibrePCB");
-  QApplication::setOrganizationDomain("librepcb.org");
-  QApplication::setApplicationName("LibrePCB");
-  QApplication::setApplicationVersion(Application::getVersion());
-  QApplication::setDesktopFileName("org.librepcb.LibrePCB");
-}
-
-/*******************************************************************************
- *  configureApplicationSettings()
- ******************************************************************************/
-
-static void configureApplicationSettings() noexcept {
-  // Make sure the INI format is used for settings on all platforms because:
-  // - Consistent storage format on all platforms
-  // - Useful for functional testing (control settings by fixtures)
-  // - Windows Registry is a mess (hard to find, edit and track changes of our
-  // settings)
-  QSettings::setDefaultFormat(QSettings::IniFormat);
-
-  // Use different configuration directory if supplied by environment variable
-  // "LIBREPCB_CONFIG_DIR" (useful for functional testing)
-  QString customConfigDir = qgetenv("LIBREPCB_CONFIG_DIR");
-  if (!customConfigDir.isEmpty()) {
-    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope,
-                       customConfigDir);
-  }
-}
-
-/*******************************************************************************
- *  writeLogHeader()
- ******************************************************************************/
-
-static void writeLogHeader() noexcept {
-  // write application name and version to log
-  qInfo().noquote() << QString("LibrePCB %1 (%2)")
-                           .arg(Application::getVersion(),
-                                Application::getGitRevision());
-
-  // write Qt version to log
-  qInfo().noquote() << QString("Qt version: %1 (compiled against %2)")
-                           .arg(qVersion(), QT_VERSION_STR);
-
-  // write resources directory path to log
-  qInfo() << "Resources directory:"
-          << Application::getResourcesDir().toNative();
-
-  // write application settings file to log (nice to know for users)
-  qInfo() << "Application settings:"
-          << FilePath(QSettings().fileName()).toNative();
-
-  // write cache directory to log (nice to know for users)
-  qInfo() << "Cache directory:" << Application::getCacheDir().toNative();
-}
-
-/*******************************************************************************
- *  setTheme()
- ******************************************************************************/
-
-static void setTheme(const QString& name) noexcept {
-  sTheme = UiTheme::find(name);
-  if (!sTheme) {
-    sTheme = EditorToolbox::isSystemThemeDark() ? &UiTheme::dark()
-                                                : &UiTheme::light();
-  }
-  qApp->setPalette(sTheme->qpalette);
-
-  QPixmapCache::clear();
-  for (QWidget* widget : qApp->allWidgets()) {  // NOLINT
-    qApp->style()->unpolish(widget);
-    qApp->style()->polish(widget);
-    widget->update();
-  }
-}
-
-/*******************************************************************************
- *  openWorkspace()
- ******************************************************************************/
-
-static int runApplication() noexcept {
-  // For deployment testing purposes, exit the application now if the flag
-  // '--exit-after-startup' is passed. This shall be done *before* any user
-  // interaction (e.g. message box) to make it working headless.
-  const char* exitFlagName = "--exit-after-startup";
-  if (qApp->arguments().contains(exitFlagName)) {
-    qInfo().nospace() << "Exit requested by flag '" << exitFlagName << "'.";
-    return 0;
-  }
-
-  // If the file format is unstable (e.g. for nightly builds), ask to abort now.
-  // This warning *must* come that early to be really sure that no files are
-  // overwritten with unstable content!
-  if (!isFileFormatStableOrAcceptUnstable()) {
-    return 0;
-  }
-
-  // Get the path of the workspace to open. By default, open the recently used
-  // workspace stored in the user settings.
-  FilePath path = Workspace::getMostRecentlyUsedWorkspacePath();
-  qDebug() << "Recently used workspace:" << path.toNative();
-
-  // If the workspace path is specified by environment variable, use this one.
-  const char* wsEnvVarName = "LIBREPCB_WORKSPACE";
-  QString wsEnvStr = qgetenv(wsEnvVarName);
-  if (!wsEnvStr.isEmpty()) {
-    qInfo() << "Workspace path overridden by" << wsEnvVarName
-            << "environment variable:" << wsEnvStr;
-    path.setPath(wsEnvStr);
-  }
-
-  // If creating or opening a workspace failed, allow to choose another
-  // workspace path until it succeeds or the user aborts.
-  while (true) {
-    try {
-      return openWorkspace(path);  // can throw
-    } catch (const UserCanceled& e) {
-      return 0;  // User canceled -> exit application.
-    } catch (const Exception& e) {
-      QMessageBox::critical(
-          nullptr, QApplication::translate("Workspace", "Error"),
-          QString(QApplication::translate(
-                      "Workspace", "Could not open the workspace \"%1\":"))
-                  .arg(path.toNative()) %
-              "\n\n" % e.getMsg());
-      path = FilePath();  // Make sure the workspace selector wizard is shown.
-    }
-  }
-}
-
-/*******************************************************************************
- *  isFileFormatStableOrAcceptUnstable()
- ******************************************************************************/
-
-static bool isFileFormatStableOrAcceptUnstable() noexcept {
-  if (Application::isFileFormatStable() ||
-      (qgetenv("LIBREPCB_DISABLE_UNSTABLE_WARNING") == "1")) {
-    return true;
-  } else {
-    QMessageBox::StandardButton btn = QMessageBox::critical(
-        nullptr, QCoreApplication::translate("main", "Unstable file format!"),
-        QCoreApplication::translate(
-            "main",
-            "<p><b>ATTENTION: This application version is UNSTABLE!</b></p>"
-            "<p>Everything you do with this application can break your "
-            "workspace, libraries or projects! Saved files will not be "
-            "readable with stable releases of LibrePCB. It's highly "
-            "recommended to create a backup before proceeding. If you are "
-            "unsure, please download an official stable release instead.</p>"
-            "<p>For details, please take a look at LibrePCB's "
-            "<a href=\"%1\">versioning concept</a>.</p>"
-            "<p>Are you really sure to continue with the risk of breaking your "
-            "files?!</p>")
-            .arg("https://developers.librepcb.org/da/dbc/"
-                 "doc_release_workflow.html"),
-        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
-    return (btn == QMessageBox::Yes);
-  }
-}
-
-/*******************************************************************************
- *  openWorkspace()
- ******************************************************************************/
-
-static int openWorkspace(FilePath& path) {
-  // Run initialize workspace wizard as many times as needed until a valid
-  // workspace is selected.
-  Q_ASSERT(sTheme);
-  std::unique_ptr<InitializeWorkspaceWizard> wizard(
-      new InitializeWorkspaceWizard(*sTheme, false));
-  wizard->setWorkspacePath(path);  // can throw
-  while (wizard->getNeedsToBeShown()) {
-    if (wizard->exec() != QDialog::Accepted) {
-      throw UserCanceled(__FILE__, __LINE__);
-    }
-    Workspace::setMostRecentlyUsedWorkspacePath(wizard->getWorkspacePath());
-
-    // Just to be on the safe side that the workspace is now *really* ready
-    // to open (created, upgraded, initialized, ...), check the status again
-    // before continue opening the workspace.
-    wizard->setWorkspacePath(wizard->getWorkspacePath());  // can throw
-    wizard->restart();
-  }
-
-  // Open the workspace (can throw). If it is locked, a dialog will show
-  // an error and possibly provides an option to override the lock.
-  Workspace ws(wizard->getWorkspacePath(), wizard->getDataDir(),
-               DirectoryLockHandlerDialog::createDirectoryLockCallback());
-
-  // We don't need the wizard anymore (and it disturbes the Funq tests).
-  const bool wsContainsNewerFileFormats =
-      wizard->getWorkspaceContainsNewerFileFormats();
-  wizard.reset();
-
-  // Apply UI theme from workspace settings.
-  auto applyUiTheme = [&]() { setTheme(ws.getSettings().uiTheme.get()); };
-  applyUiTheme();
-  QObject::connect(&ws.getSettings().uiTheme, &WorkspaceSettingsItem::edited,
-                   &ws.getSettings().uiTheme, applyUiTheme);
-
-  // Now since workspace settings are loaded, switch to the language defined
-  // there (until now, the system language was used).
-  // Note: Until LibrePCB 2.0.1 we also set QLocale::setDefault(locale), but
-  // this is probably wrong as the setting is intended to change only the
-  // language, not the locale. Most translation locales have no country set
-  // anyway (e.g. only "de", not "de_CH"), so we don't know the user's country.
-  auto applyApplicationLocale = [&ws]() {
-    const QString name = ws.getSettings().applicationLocale.get();
-    const QLocale locale = name.isEmpty() ? QLocale::system() : QLocale(name);
-    Application::setTranslationLocale(locale);
-    EditorCommandSet::instance().updateTranslations();
-    slint::update_all_translations();
-  };
-  applyApplicationLocale();
-  QObject::connect(&ws.getSettings().applicationLocale,
-                   &WorkspaceSettingsItem::edited,
-                   &ws.getSettings().applicationLocale, applyApplicationLocale);
-
-  // Setup global parts information provider (with cache).
-  PartInformationProvider::instance().setCacheDir(Application::getCacheDir());
-  auto applyPartInformationProviderSettings = [&ws]() {
-    const auto ep = ws.getSettings().getApiEndpointForPartsInfo();
-    PartInformationProvider::instance().setApiEndpoint(ep ? ep->url : QUrl());
-  };
-  applyPartInformationProviderSettings();
-  QObject::connect(
-      &ws.getSettings().apiEndpoints, &WorkspaceSettingsItem::edited,
-      &ws.getSettings().apiEndpoints, applyPartInformationProviderSettings);
-
-  // Apply keyboard shortcuts from workspace settings globally.
-  auto applyKeyboardShortcuts = [&ws]() {
-    const auto& overrides = ws.getSettings().keyboardShortcuts.get();
-    EditorCommandSet& set = EditorCommandSet::instance();
-    foreach (EditorCommandCategory* category, set.getCategories()) {
-      foreach (EditorCommand* command, set.getCommands(category)) {
-        QList<QKeySequence> sequences =
-            overrides.contains(command->getIdentifier())
-            ? overrides.value(command->getIdentifier())
-            : command->getDefaultKeySequences();
-        command->setKeySequences(sequences);
-      }
-    }
-  };
-  applyKeyboardShortcuts();
-  QObject::connect(&ws.getSettings().keyboardShortcuts,
-                   &WorkspaceSettingsItem::edited,
-                   &ws.getSettings().keyboardShortcuts, applyKeyboardShortcuts);
-
-  // Run the application.
-  GuiApplication app(ws, wsContainsNewerFileFormats, sTheme);
-  app.exec();
-  return 0;
+  // Run application
+  cli::CommandLineInterface cli;
+  return cli.execute(app.arguments());
 }

--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -55,6 +55,10 @@ BoardDesignRules::BoardDesignRules() noexcept
     mPadAnnularRing(UnsignedRatio(Ratio::fromPercent(25)),  // 25%
                     UnsignedLength(250000),  // 0.25mm
                     UnsignedLength(2000000)),  // 2mm
+    // pad copper expansion
+    mPadCopperExpansion(UnsignedRatio(Ratio::fromPercent(0)),  // 0%
+                        UnsignedLength(0),  // 0mm
+                        UnsignedLength(2000000)),  // 2mm
     // via annular ring
     mViaAnnularRing(UnsignedRatio(Ratio::fromPercent(25)),  // 25%
                     UnsignedLength(200000),  // 0.2mm
@@ -85,6 +89,13 @@ BoardDesignRules::BoardDesignRules(const SExpression& node)
     mPadInnerAutoAnnularRing(
         parsePadAutoAnnular(node.getChild("pad_annular_ring/inner/@0"))),
     mPadAnnularRing(node.getChild("pad_annular_ring")),
+    // pad copper expansion
+    mPadCopperExpansion(node.tryGetChild("pad_copper_expansion")
+                            ? BoundedUnsignedRatio(
+                                  *node.tryGetChild("pad_copper_expansion"))
+                            : BoundedUnsignedRatio(
+                                  UnsignedRatio(Ratio::fromPercent(0)),
+                                  UnsignedLength(0), UnsignedLength(2000000))),
     // via annular ring
     mViaAnnularRing(node.getChild("via_annular_ring")) {
 }
@@ -132,18 +143,18 @@ void BoardDesignRules::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("default_via_drill_diameter", mDefaultViaDrillDiameter);
 
-  // stop mask
+          // stop mask
   root.ensureLineBreak();
   root.appendChild("stopmask_max_via_drill_diameter",
                    mStopMaskMaxViaDrillDiameter);
   root.ensureLineBreak();
   mStopMaskClearance.serialize(root.appendList("stopmask_clearance"));
 
-  // solder paste
+          // solder paste
   root.ensureLineBreak();
   mSolderPasteClearance.serialize(root.appendList("solderpaste_clearance"));
 
-  // pad annular ring
+          // pad annular ring
   {
     root.ensureLineBreak();
     SExpression& node = root.appendList("pad_annular_ring");
@@ -156,7 +167,11 @@ void BoardDesignRules::serialize(SExpression& root) const {
     mPadAnnularRing.serialize(node);
   }
 
-  // via annular ring
+          // pad copper expansion
+  root.ensureLineBreak();
+  mPadCopperExpansion.serialize(root.appendList("pad_copper_expansion"));
+
+          // via annular ring
   root.ensureLineBreak();
   mViaAnnularRing.serialize(root.appendList("via_annular_ring"));
 
@@ -190,6 +205,8 @@ BoardDesignRules& BoardDesignRules::operator=(
   mPadCmpSideAutoAnnularRing = rhs.mPadCmpSideAutoAnnularRing;
   mPadInnerAutoAnnularRing = rhs.mPadInnerAutoAnnularRing;
   mPadAnnularRing = rhs.mPadAnnularRing;
+  // pad copper expansion
+  mPadCopperExpansion = rhs.mPadCopperExpansion;
   // via annular ring
   mViaAnnularRing = rhs.mViaAnnularRing;
   return *this;
@@ -210,6 +227,8 @@ bool BoardDesignRules::operator==(const BoardDesignRules& rhs) const noexcept {
     return false;
   if (mPadInnerAutoAnnularRing != rhs.mPadInnerAutoAnnularRing) return false;
   if (mPadAnnularRing != rhs.mPadAnnularRing) return false;
+  // pad copper expansion
+  if (mPadCopperExpansion != rhs.mPadCopperExpansion) return false;
   // via annular ring
   if (mViaAnnularRing != rhs.mViaAnnularRing) return false;
   return true;

--- a/libs/librepcb/core/project/board/boarddesignrules.h
+++ b/libs/librepcb/core/project/board/boarddesignrules.h
@@ -53,7 +53,7 @@ public:
   explicit BoardDesignRules(const SExpression& node);
   ~BoardDesignRules() noexcept;
 
-  // Getters: Default Values
+          // Getters: Default Values
   const PositiveLength& getDefaultTraceWidth() const noexcept {
     return mDefaultTraceWidth;
   }
@@ -61,7 +61,7 @@ public:
     return mDefaultViaDrillDiameter;
   }
 
-  // Getters: Stop Mask
+          // Getters: Stop Mask
   const UnsignedLength& getStopMaskMaxViaDiameter() const noexcept {
     return mStopMaskMaxViaDrillDiameter;
   }
@@ -69,12 +69,12 @@ public:
     return mStopMaskClearance;
   }
 
-  // Getters: Solder Paste
+          // Getters: Solder Paste
   const BoundedUnsignedRatio& getSolderPasteClearance() const noexcept {
     return mSolderPasteClearance;
   }
 
-  // Getters: Pad Annular Ring
+          // Getters: Pad Annular Ring
   bool getPadCmpSideAutoAnnularRing() const noexcept {
     return mPadCmpSideAutoAnnularRing;
   }
@@ -85,12 +85,17 @@ public:
     return mPadAnnularRing;
   }
 
-  // Getters: Via Annular Ring
+          // Getters: Pad Copper Expansion
+  const BoundedUnsignedRatio& getPadCopperExpansion() const noexcept {
+    return mPadCopperExpansion;
+  }
+
+          // Getters: Via Annular Ring
   const BoundedUnsignedRatio& getViaAnnularRing() const noexcept {
     return mViaAnnularRing;
   }
 
-  // Setters
+          // Setters
   void setDefaultTraceWidth(const PositiveLength& value) noexcept {
     mDefaultTraceWidth = value;
   }
@@ -115,11 +120,14 @@ public:
   void setPadAnnularRing(const BoundedUnsignedRatio& value) {
     mPadAnnularRing = value;
   }
+  void setPadCopperExpansion(const BoundedUnsignedRatio& value) {
+    mPadCopperExpansion = value;
+  }
   void setViaAnnularRing(const BoundedUnsignedRatio& value) {
     mViaAnnularRing = value;
   }
 
-  // General Methods
+          // General Methods
   void restoreDefaults() noexcept;
   void adjustToDrcSettings(const BoardDesignRuleCheckSettings& s) noexcept;
 
@@ -130,10 +138,10 @@ public:
    */
   void serialize(SExpression& root) const;
 
-  // Helper Methods
+          // Helper Methods
   bool doesViaRequireStopMaskOpening(const Length& drillDia) const noexcept;
 
-  // Operator Overloadings
+          // Operator Overloadings
   BoardDesignRules& operator=(const BoardDesignRules& rhs) noexcept;
   bool operator==(const BoardDesignRules& rhs) const noexcept;
   bool operator!=(const BoardDesignRules& rhs) const noexcept {
@@ -148,19 +156,23 @@ private:  // Data
   PositiveLength mDefaultTraceWidth;
   PositiveLength mDefaultViaDrillDiameter;
 
-  // Stop Mask
+          // Stop Mask
   UnsignedLength mStopMaskMaxViaDrillDiameter;
   BoundedUnsignedRatio mStopMaskClearance;
 
-  // Solder Paste
+          // Solder Paste
   BoundedUnsignedRatio mSolderPasteClearance;
 
-  // Pad Annular Ring
+          // Pad Annular Ring
   bool mPadCmpSideAutoAnnularRing;
   bool mPadInnerAutoAnnularRing;
   BoundedUnsignedRatio mPadAnnularRing;  /// Percentage of the drill diameter
 
-  // Via Annular Ring
+          // Pad Copper Expansion
+  BoundedUnsignedRatio
+      mPadCopperExpansion;  /// Percentage of pad size, expands copper shape
+
+          // Via Annular Ring
   BoundedUnsignedRatio mViaAnnularRing;  /// Percentage of the drill diameter
 };
 

--- a/libs/librepcb/core/project/board/items/bi_pad.cpp
+++ b/libs/librepcb/core/project/board/items/bi_pad.cpp
@@ -660,6 +660,21 @@ QList<PadGeometry> BI_Pad::getGeometryOnCopperLayer(
           PadHoleList{std::make_shared<PadHole>(hole)}));
     }
   }
+
+  // Apply the global copper expansion (in percent of the pad size), as
+  // configured in the board design rules. This lets the user enlarge all
+  // copper pad shapes on the board, e.g. for easier hand soldering.
+  const UnsignedLength copperExpansion =
+      mBoard.getDesignRules().getPadCopperExpansion().calcValue(
+          *getSizeForMaskOffsetCalculation());
+  if (*copperExpansion > 0) {
+    QList<PadGeometry> expanded;
+    foreach (const PadGeometry& pg, result) {
+      expanded.append(pg.withOffset(*copperExpansion));
+    }
+    result = expanded;
+  }
+
   return result;
 }
 

--- a/libs/librepcb/editor/project/board/boardsetupdialog.cpp
+++ b/libs/librepcb/editor/project/board/boardsetupdialog.cpp
@@ -67,7 +67,7 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &BoardSetupDialog::buttonBoxClicked);
 
-  // Tab: General
+          // Tab: General
   mUi->spbxInnerCopperLayerCount->setMinimum(0);
   mUi->spbxInnerCopperLayerCount->setMaximum(Layer::innerCopperCount());
   mUi->edtPcbThickness->setToolTip(tr("Default:") % " 1.6 mm");
@@ -107,7 +107,7 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   mUi->cbxSilkBotNames->setText(Layer::botNames().getNameTr());
   mUi->cbxSilkBotValues->setText(Layer::botValues().getNameTr());
 
-  // Tab: Design Rules
+          // Tab: Design Rules
   mUi->edtDefaultTraceWidth->configure(
       mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
       sSettingsPrefix % "/default_trace_width");
@@ -128,6 +128,13 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   mUi->edtRulesSolderPasteClrMax->configure(
       mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
       sSettingsPrefix % "/solderpaste_clearance_max");
+  mUi->edtRulesPadCopperExpansionRatio->setSingleStep(5.0);  // [%]
+  mUi->edtRulesPadCopperExpansionMin->configure(
+      mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
+      sSettingsPrefix % "/pad_copper_expansion_min");
+  mUi->edtRulesPadCopperExpansionMax->configure(
+      mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
+      sSettingsPrefix % "/pad_copper_expansion_max");
   mUi->edtRulesPadAnnularRingRatio->setSingleStep(5.0);  // [%]
   mUi->edtRulesPadAnnularRingMin->configure(
       mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
@@ -174,6 +181,14 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
           mUi->edtRulesSolderPasteClrMax, &UnsignedLengthEdit::clipToMinimum);
   connect(mUi->edtRulesSolderPasteClrMax, &UnsignedLengthEdit::valueChanged,
           mUi->edtRulesSolderPasteClrMin, &UnsignedLengthEdit::clipToMaximum);
+  connect(mUi->edtRulesPadCopperExpansionMin,
+          &UnsignedLengthEdit::valueChanged,
+          mUi->edtRulesPadCopperExpansionMax,
+          &UnsignedLengthEdit::clipToMinimum);
+  connect(mUi->edtRulesPadCopperExpansionMax,
+          &UnsignedLengthEdit::valueChanged,
+          mUi->edtRulesPadCopperExpansionMin,
+          &UnsignedLengthEdit::clipToMaximum);
   connect(mUi->edtRulesPadAnnularRingMin, &UnsignedLengthEdit::valueChanged,
           mUi->edtRulesPadAnnularRingMax, &UnsignedLengthEdit::clipToMinimum);
   connect(mUi->edtRulesPadAnnularRingMax, &UnsignedLengthEdit::valueChanged,
@@ -183,7 +198,7 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   connect(mUi->edtRulesViaAnnularRingMax, &UnsignedLengthEdit::valueChanged,
           mUi->edtRulesViaAnnularRingMin, &UnsignedLengthEdit::clipToMaximum);
 
-  // Tab: DRC Settings
+          // Tab: DRC Settings
   connect(mUi->btnLoadDrcSettings, &QToolButton::clicked, this,
           [this]() { loadDrcSettingsPreset(); });
   connect(mUi->lblDrcConfigName, &QLabel::linkActivated, this,
@@ -258,17 +273,17 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
         QVariant::fromValue(BoardDesignRuleCheckSettings::AllowedSlots::Any));
   }
 
-  // Load all settings.
+          // Load all settings.
   load();
 
-  // Load client settings.
+          // Load client settings.
   QSettings cs;
   const QSize windowSize = cs.value(sSettingsPrefix % "/window_size").toSize();
   if (!windowSize.isEmpty()) {
     resize(windowSize);
   }
 
-  // Always open first tab.
+          // Always open first tab.
   mUi->tabWidget->setCurrentIndex(0);
 }
 
@@ -333,7 +348,7 @@ void BoardSetupDialog::load() noexcept {
   mUi->cbxSilkBotNames->setChecked(botLegend.contains(&Layer::botNames()));
   mUi->cbxSilkBotValues->setChecked(botLegend.contains(&Layer::botValues()));
 
-  // Tab: Design Rules
+          // Tab: Design Rules
   const BoardDesignRules& r = mBoard.getDesignRules();
   mUi->edtDefaultTraceWidth->setValue(r.getDefaultTraceWidth());
   mUi->edtDefaultViaDrill->setValue(r.getDefaultViaDrillDiameter());
@@ -356,6 +371,12 @@ void BoardSetupDialog::load() noexcept {
   } else {
     mUi->rbtnRulesInnerPadFullShape->setChecked(true);
   }
+  mUi->edtRulesPadCopperExpansionRatio->setValue(
+      r.getPadCopperExpansion().getRatio());
+  mUi->edtRulesPadCopperExpansionMin->setValue(
+      r.getPadCopperExpansion().getMinValue());
+  mUi->edtRulesPadCopperExpansionMax->setValue(
+      r.getPadCopperExpansion().getMaxValue());
   mUi->edtRulesPadAnnularRingRatio->setValue(r.getPadAnnularRing().getRatio());
   mUi->edtRulesPadAnnularRingMin->setValue(r.getPadAnnularRing().getMinValue());
   mUi->edtRulesPadAnnularRingMax->setValue(r.getPadAnnularRing().getMaxValue());
@@ -364,7 +385,7 @@ void BoardSetupDialog::load() noexcept {
   mUi->edtRulesViaAnnularRingMax->setValue(r.getViaAnnularRing().getMaxValue());
   mUi->edtRulesStopMaskMaxViaDia->setValue(r.getStopMaskMaxViaDiameter());
 
-  // Tab: DRC Settings
+          // Tab: DRC Settings
   loadDrcSources(mBoard.getDrcSettings().getSources());
   loadDrcSettings(mBoard.getDrcSettings());
 }
@@ -535,7 +556,7 @@ bool BoardSetupDialog::apply() noexcept {
   try {
     std::unique_ptr<CmdBoardEdit> cmd(new CmdBoardEdit(mBoard));
 
-    // Tab: General
+            // Tab: General
     cmd->setName(
         ElementName(mUi->edtBoardName->text().trimmed()));  // can throw
     cmd->setInnerLayerCount(mUi->spbxInnerCopperLayerCount->value());
@@ -545,13 +566,13 @@ bool BoardSetupDialog::apply() noexcept {
           mUi->cbxSolderResist->currentData().value<const PcbColor*>());
     }
     if (const PcbColor* color =
-            mUi->cbxSilkscreenColor->currentData().value<const PcbColor*>()) {
+        mUi->cbxSilkscreenColor->currentData().value<const PcbColor*>()) {
       cmd->setSilkscreenColor(*color);
     }
     cmd->setSilkscreenLayersTop(getTopSilkscreenLayers());
     cmd->setSilkscreenLayersBot(getBotSilkscreenLayers());
 
-    // Tab: Design Rules
+            // Tab: Design Rules
     BoardDesignRules r = mBoard.getDesignRules();
     r.setDefaultTraceWidth(mUi->edtDefaultTraceWidth->getValue());
     r.setDefaultViaDrillDiameter(mUi->edtDefaultViaDrill->getValue());
@@ -571,6 +592,10 @@ bool BoardSetupDialog::apply() noexcept {
         mUi->edtRulesPadAnnularRingRatio->getValue(),
         mUi->edtRulesPadAnnularRingMin->getValue(),
         mUi->edtRulesPadAnnularRingMax->getValue()));  // can throw
+    r.setPadCopperExpansion(BoundedUnsignedRatio(
+        mUi->edtRulesPadCopperExpansionRatio->getValue(),
+        mUi->edtRulesPadCopperExpansionMin->getValue(),
+        mUi->edtRulesPadCopperExpansionMax->getValue()));  // can throw
     r.setViaAnnularRing(BoundedUnsignedRatio(
         mUi->edtRulesViaAnnularRingRatio->getValue(),
         mUi->edtRulesViaAnnularRingMin->getValue(),
@@ -578,7 +603,7 @@ bool BoardSetupDialog::apply() noexcept {
     r.setStopMaskMaxViaDiameter(mUi->edtRulesStopMaskMaxViaDia->getValue());
     cmd->setDesignRules(r);
 
-    // Tab: DRC Settings
+            // Tab: DRC Settings
     BoardDesignRuleCheckSettings s = mBoard.getDrcSettings();
     s.setSources(mDrcSources);
     s.setMinCopperCopperClearance(mUi->edtDrcClearanceCopperCopper->getValue());

--- a/libs/librepcb/editor/project/board/boardsetupdialog.ui
+++ b/libs/librepcb/editor/project/board/boardsetupdialog.ui
@@ -281,7 +281,26 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0" colspan="4">
+       <item row="14" column="0">
+        <widget class="QLabel" name="label_37">
+         <property name="toolTip">
+          <string>Enlarges all copper pad shapes on the board by this percentage of the pad size (e.g. useful for easier hand soldering). Set to 0% to disable.</string>
+         </property>
+         <property name="text">
+          <string>Pads Copper Expansion:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1">
+        <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRulesPadCopperExpansionMin" native="true"/>
+       </item>
+       <item row="14" column="2">
+        <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRulesPadCopperExpansionRatio" native="true"/>
+       </item>
+       <item row="14" column="3">
+        <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRulesPadCopperExpansionMax" native="true"/>
+       </item>
+       <item row="15" column="0" colspan="4">
         <widget class="QLabel" name="label_3">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -566,7 +585,7 @@ QAbstractScrollArea {
             <x>0</x>
             <y>0</y>
             <width>753</width>
-            <height>380</height>
+            <height>354</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -963,6 +982,12 @@ QAbstractScrollArea {
  </widget>
  <customwidgets>
   <customwidget>
+   <class>librepcb::editor::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>librepcb::editor::UnsignedLengthEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
@@ -972,12 +997,6 @@ QAbstractScrollArea {
    <class>librepcb::editor::UnsignedRatioEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/unsignedratioedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::editor::PositiveLengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -1015,7 +1034,7 @@ QAbstractScrollArea {
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="btnGroupRulesCmpSidePadShape"/>
   <buttongroup name="btnGroupRulesInnerPadShape"/>
+  <buttongroup name="btnGroupRulesCmpSidePadShape"/>
  </buttongroups>
 </ui>

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
@@ -49,6 +49,8 @@
 #include <librepcb/core/project/board/items/bi_zone.h>
 #include <librepcb/core/project/project.h>
 
+#include <cmath>
+
 #include <QtCore>
 
 /*******************************************************************************
@@ -74,7 +76,9 @@ CmdDragSelectedBoardItems::CmdDragSelectedBoardItems(
     mSnappedToGrid(false),
     mLockedChanged(false),
     mLineWidthChanged(false),
-    mTextsReset(false) {
+    mTextsReset(false),
+    mHasReferenceDirection(false),
+    mReferenceDirection(1, 0) {
   // get all selected items
   BoardSelectionQuery query(mScene, includeLockedItems);
   query.addDeviceInstancesOfSelectedFootprints();
@@ -92,6 +96,33 @@ CmdDragSelectedBoardItems::CmdDragSelectedBoardItems(
   query.addSelectedBoardStrokeTexts();
   query.addSelectedFootprintStrokeTexts();
   query.addSelectedHoles();
+
+  // Determine the reference direction used to constrain the drag movement
+  // (see documentation of #mReferenceDirection). Prefer the direction of an
+  // explicitly selected/dragged trace segment; if only a lone junction
+  // point is being dragged, fall back to the direction of one of its
+  // connected segments so that segment keeps its angle.
+  auto tryUseDirection = [&](const Point& a, const Point& b) {
+    if (mHasReferenceDirection) return;
+    QPointF dir = b.toMmQPointF() - a.toMmQPointF();
+    const qreal len = std::hypot(dir.x(), dir.y());
+    if (len > 1e-9) {
+      mReferenceDirection = dir / len;
+      mHasReferenceDirection = true;
+    }
+  };
+  foreach (BI_NetLine* netline, query.getNetLines()) {
+    tryUseDirection(netline->getP1().getPosition(),
+                    netline->getP2().getPosition());
+  }
+  if (!mHasReferenceDirection) {
+    foreach (BI_NetPoint* netpoint, query.getNetPoints()) {
+      foreach (BI_NetLine* netline, netpoint->getNetLines()) {
+        tryUseDirection(netline->getP1().getPosition(),
+                        netline->getP2().getPosition());
+      }
+    }
+  }
 
   // Expand the selected individual pads to their devices, to allow dragging
   // the devices (individual footprint pads cannot be dragged). However, the
@@ -127,6 +158,31 @@ CmdDragSelectedBoardItems::CmdDragSelectedBoardItems(
     ++mItemCount;
     CmdBoardNetPointEdit* cmd = new CmdBoardNetPointEdit(*netpoint);
     mNetPointEditCmds.append(cmd);
+
+    // Find (at most) one neighbor trace connected to this point which is
+    // *not* part of the current selection. That neighbor stays where it is
+    // and must keep its own original angle - see #NetPointConstraint.
+    NetPointConstraint constraint;
+    constraint.cmd = cmd;
+    constraint.originalPos = netpoint->getPosition();
+    foreach (BI_NetLine* netline, netpoint->getNetLines()) {
+      if (query.getNetLines().contains(netline)) {
+        continue;  // Dragged along as well -> not a fixed neighbor.
+      }
+      BI_NetLineAnchor& farAnchor = (&netline->getP1() == netpoint)
+          ? netline->getP2()
+          : netline->getP1();
+      QPointF dir = netpoint->getPosition().toMmQPointF() -
+          farAnchor.getPosition().toMmQPointF();
+      const qreal len = std::hypot(dir.x(), dir.y());
+      if (len > 1e-9) {
+        constraint.hasNeighborRay = true;
+        constraint.neighborFixedPoint = farAnchor.getPosition().toMmQPointF();
+        constraint.neighborDirection = dir / len;
+        break;  // Only the first fixed neighbor is used as a constraint.
+      }
+    }
+    mNetPointConstraints.append(constraint);
   }
   foreach (BI_NetLine* netline, query.getNetLines()) {
     Q_ASSERT(netline);
@@ -305,9 +361,54 @@ void CmdDragSelectedBoardItems::resetAllTexts() noexcept {
   mTextsReset = true;
 }
 
+Point CmdDragSelectedBoardItems::computeNetPointPosition(
+    const NetPointConstraint& c, const Point& delta) const noexcept {
+  // Point on the shifted reference line (dragged segment offset by delta,
+  // keeping its own original direction).
+  const QPointF p1 = c.originalPos.toMmQPointF() + delta.toMmQPointF();
+
+  if ((!c.hasNeighborRay) || (!mHasReferenceDirection)) {
+    // No fixed neighbor (or no reference direction at all) -> just follow
+    // the shifted line / rigid translation.
+    return c.originalPos + delta;
+  }
+
+  // Intersect the shifted reference line (p1, mReferenceDirection) with the
+  // neighbor's fixed-angle ray (neighborFixedPoint, neighborDirection).
+  // Solving p1 + s*d1 == p2 + t*d2 for s (Cramer's rule):
+  const QPointF& d1 = mReferenceDirection;
+  const QPointF& d2 = c.neighborDirection;
+  const QPointF& p2 = c.neighborFixedPoint;
+  const qreal det = d1.x() * d2.y() - d1.y() * d2.x();
+  if (std::fabs(det) < 1e-9) {
+    // Parallel to the neighbor -> no unique intersection, best effort:
+    // just follow the shifted line.
+    return c.originalPos + delta;
+  }
+  const QPointF diff = p2 - p1;
+  const qreal s = (diff.x() * d2.y() - diff.y() * d2.x()) / det;
+  const QPointF intersection = p1 + s * d1;
+  return Point::fromMm(intersection);
+}
+
 void CmdDragSelectedBoardItems::setCurrentPosition(
     const Point& pos, const bool gridIncrement) noexcept {
   Point delta = pos - mStartPos;
+
+  if (mHasReferenceDirection) {
+    // Keep the reference trace (and everything moved rigidly together with
+    // it) at its exact original angle: only the component of the movement
+    // that is perpendicular to the reference direction is allowed. A pure
+    // translation along that perpendicular can never rotate the line, so a
+    // horizontal/vertical trace stays perfectly parallel to the grid axes,
+    // and a trace drawn at any other angle keeps that exact angle - just
+    // like dragging a track in KiCad or a wire in Eagle.
+    const QPointF perp(-mReferenceDirection.y(), mReferenceDirection.x());
+    const QPointF d = delta.toMmQPointF();
+    const qreal t = d.x() * perp.x() + d.y() * perp.y();
+    delta = Point::fromMm(t * perp.x(), t * perp.y());
+  }
+
   if (gridIncrement) {
     delta.mapToGrid(mScene.getBoard().getGridInterval());
   }
@@ -323,8 +424,8 @@ void CmdDragSelectedBoardItems::setCurrentPosition(
     foreach (CmdBoardViaEdit* cmd, mViaEditCmds) {
       cmd->translate(delta - mDeltaPos, true);
     }
-    foreach (CmdBoardNetPointEdit* cmd, mNetPointEditCmds) {
-      cmd->translate(delta - mDeltaPos, true);
+    foreach (const NetPointConstraint& c, mNetPointConstraints) {
+      c.cmd->setPosition(computeNetPointPosition(c, delta), true);
     }
     foreach (CmdBoardPlaneEdit* cmd, mPlaneEditCmds) {
       cmd->translate(delta - mDeltaPos, true);

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.h
@@ -112,6 +112,56 @@ private:
   /// Auto-selected devices used for #selectDevicesOfPads()
   QSet<BI_Device*> mAutoSelectedDevices;
 
+  /**
+   * @brief Constraint direction determined from the dragged trace itself.
+   *
+   * Like in KiCad/Eagle: the reference for "keep the angle" is the
+   * *original* direction of the dragged trace segment (or, if a lone
+   * junction point without an own selected segment was grabbed, the
+   * direction of one of its connected segments). Horizontal traces have a
+   * horizontal reference direction, vertical traces a vertical one, 45°
+   * traces a 45° one, etc.
+   *
+   * While dragging, the mouse-delta is projected onto the perpendicular of
+   * this reference direction and *only* that perpendicular component is
+   * applied as translation to every selected item. Since a pure
+   * translation can never change a segment's own direction, this
+   * guarantees:
+   *  - horizontal/vertical traces always stay exactly horizontal/vertical
+   *    (i.e. parallel to the grid axes), and
+   *  - traces drawn at any other angle keep that exact angle (in degrees),
+   * no matter how the mouse is moved - exactly like dragging a track in
+   * KiCad or a wire in Eagle.
+   */
+  bool mHasReferenceDirection;
+  QPointF mReferenceDirection;  ///< normalized, only valid if
+                                 ///< #mHasReferenceDirection is true
+
+  /**
+   * @brief Per-point info needed for the KiCad/Eagle-style "trombone" drag.
+   *
+   * If the point has a fixed (non-dragged) neighbor trace, that neighbor
+   * must keep its own original angle - only its length may change. Since
+   * the dragged point must, at the same time, stay exactly on the shifted
+   * reference line (see #mReferenceDirection), its new position is the
+   * intersection of both lines: the shifted reference line and the
+   * neighbor's fixed-angle ray. This way *both* the dragged segment and
+   * the untouched neighbor keep their exact original angle; only lengths
+   * adapt - exactly like in KiCad or Eagle.
+   */
+  struct NetPointConstraint {
+    CmdBoardNetPointEdit* cmd;
+    Point originalPos;
+    bool hasNeighborRay = false;
+    QPointF neighborFixedPoint;
+    QPointF neighborDirection;  ///< normalized
+  };
+
+  Point computeNetPointPosition(const NetPointConstraint& c,
+                                const Point& delta) const noexcept;
+
+  QVector<NetPointConstraint> mNetPointConstraints;
+
   // Move commands
   QList<CmdDeviceInstanceEdit*> mDeviceEditCmds;
   QList<CmdDeviceStrokeTextsReset*> mDeviceStrokeTextsResetCmds;


### PR DESCRIPTION
Hi! Thanks for the quick feedback and sorry for the mess with the Git history.

I have recreated the PR properly against the latest `master` branch so it now contains strictly my changes.

To answer your questions regarding the functionality:

1. **Trace dragging (KiCad/EAGLE style):**
   - It improves the trace editing workflow in the board/schematic editor. Instead of having to delete and redraw a trace segment or move individual nodes, dragging a trace line automatically keeps adjacent segments connected and moves the line perpendicular to its axis (similar to the interactive routing/dragging behavior found in KiCad or EAGLE).

2. **Copper pad expansion in Design Rules (DRC):**
   - It introduces a new setting in the Design Rules to control the global or rule-based copper clearance/expansion around pads.
   - **Is it related to trace dragging?** No, these are two independent features bundled in the same PR. I can split them into two separate Pull Requests if you prefer.
<img width="822" height="518" alt="Snímka obrazovky 2026-08-16 222130" src="https://github.com/user-attachments/assets/d05ac50c-de0f-49f7-9675-bb7d29b3dae8" />

Uploading Záznam obrazovky 2026-08-16 222200.mp4…

