### PR TITLE
UNIX/Linux: Use user-specific temporary directory

### DIFF
--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -195,6 +195,9 @@ static void writeLogHeader() noexcept {
 
   // write cache directory to log (nice to know for users)
   qInfo() << "Cache directory:" << Application::getCacheDir().toNative();
+
+  // write temp directory to log (nice to know for devs/packagers)
+  qInfo() << "Temp directory:" << FilePath::getApplicationTempPath().toNative();
 }
 
 /*******************************************************************************

--- a/apps/librepcb/main.cpp
+++ b/apps/librepcb/main.cpp
@@ -197,7 +197,7 @@ static void writeLogHeader() noexcept {
   qInfo() << "Cache directory:" << Application::getCacheDir().toNative();
 
   // write temp directory to log (nice to know for devs/packagers)
-  qInfo() << "Temp directory:" << FilePath::getApplicationTempPath().toNative();
+  qInfo() << "Temp directory:" << Application::getTempDir().toNative();
 }
 
 /*******************************************************************************

--- a/libs/librepcb/core/3d/occmodel.cpp
+++ b/libs/librepcb/core/3d/occmodel.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "occmodel.h"
 
+#include "../application.h"
 #include "../exceptions.h"
 #include "../fileio/filepath.h"
 #include "../fileio/fileutils.h"
@@ -701,7 +702,7 @@ std::unique_ptr<OccModel> OccModel::loadStep(const QByteArray content) {
     std::istringstream is(content.data());
     const IFSelect_ReturnStatus ret = reader.ReadStream("stream.step", is);
 #else
-    FilePath tmp = FilePath::getRandomTempPath();
+    const FilePath tmp = Application::getRandomTempPath();
     FileUtils::writeFile(tmp, content);  // can throw
     const IFSelect_ReturnStatus ret = reader.ReadFile(qPrintable(tmp.toStr()));
     FileUtils::removeFile(tmp);  // can throw

--- a/libs/librepcb/core/application.cpp
+++ b/libs/librepcb/core/application.cpp
@@ -115,6 +115,49 @@ QString Application::buildFullVersionDetails() noexcept {
   return details.join("\n");
 }
 
+FilePath Application::getTempDir() noexcept {
+  auto detect = []() {
+    // Use different temporary directory if supplied by environment variable
+    // "LIBREPCB_TEMP_DIR" (e.g. for deployment). However, this is just a
+    // safety fallback which is not communicated publicly. If no problems occur
+    // with the default temp path, we should remove this fallback some day.
+    FilePath fp(qgetenv("LIBREPCB_TEMP_DIR"));
+    if (fp.isValid()) {
+      return fp;
+    }
+
+    // Note: Temporary directory has to be per-user, see
+    // https://github.com/LibrePCB/LibrePCB/issues/1871.
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)  // UNIX/Linux
+    // QStandardPaths::RuntimeLocation is a per-user directory on UNIX systems.
+    fp.setPath(
+        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation));
+#else
+    // QStandardPaths::RuntimeLocation cannot be used on macOS/Windows since
+    // it would return a really strange/wrong directory. However,
+    // QStandardPaths::TempLocation is a per-user directory on those systems,
+    // so we can use it instead.
+    fp.setPath(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+#endif
+    if (!fp.isValid()) {
+      qCritical() << "Could not determine the system's temporary directory!";
+    }
+    return fp.getPathTo("LibrePCB");
+  };
+
+  static const FilePath value = detect();
+  return value;
+}
+
+FilePath Application::getRandomTempPath() noexcept {
+  // Attention: This pattern is assumed by
+  // Application::cleanTemporaryDirectory() to detect the age of tmp files!
+  const QString random = QString("%1_%2")
+                             .arg(QDateTime::currentMSecsSinceEpoch())
+                             .arg(QRandomGenerator::global()->generate());
+  return getTempDir().getPathTo(random);
+}
+
 FilePath Application::getCacheDir() noexcept {
   auto detect = []() {
     // Use different configuration directory if supplied by environment
@@ -335,7 +378,7 @@ void Application::setTranslationLocale(const QLocale& locale) noexcept {
 void Application::cleanTemporaryDirectory() noexcept {
   const qint64 maxAgeMs = 60LL * 24LL * 3600LL * 1000LL;  // 60 days
 
-  QDir dir(FilePath::getApplicationTempPath().toStr());
+  QDir dir(getTempDir().toStr());
   dir.setFilter(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
   foreach (const QFileInfo& info, dir.entryInfoList()) {
     bool ok = false;

--- a/libs/librepcb/core/application.h
+++ b/libs/librepcb/core/application.h
@@ -117,6 +117,44 @@ public:
   static QString buildFullVersionDetails() noexcept;
 
   /**
+   * @brief Get the path to the application's temporary directory
+   *
+   * Typically returned paths:
+   *
+   * - Windows: `C:/Users/$USER/AppData/Local/Temp/LibrePCB`
+   * - MacOS: Random, e.g.
+   *   `/private/var/folders/g3/pffjr_y96bq06blnkf72x_hw0000gn/T/LibrePCB`
+   * - Linux:
+   *   - `$XDG_RUNTIME_DIR/LibrePCB` -> `/run/user/$USER/LibrePCB`
+   *   - `$TMPDIR/runtime-$USER/LibrePCB` -> `/tmp/runtime-$USER/LibrePCB`
+   *   - `/tmp/runtime-$USER/LibrePCB`
+   *
+   * @note This function is thread-safe.
+   *
+   * @attention Do not use this to store any files in it!
+   *            Use #getRandomTempPath() instead.
+   *
+   * @return Guaranteed valid file path to a librepcb-specific directory
+   *         for the current user (i.e. this temp dir is neither shared
+   *         between applications, not shared between users). However, the
+   *         directory may not exist (yet).
+   */
+  static FilePath getTempDir() noexcept;
+
+  /**
+   * @brief Get a random temporary file path
+   *
+   * This will return a path inside the directory #getTempDir(),
+   * which then can be used to create a temporary file or folder. The random
+   * name follows the pattern `<UNIX_TIMESTAMP_MS>_<RANDOM_NUMBER>` as required
+   * by ::librepcb::Application::cleanTemporaryDirectory() for the automatic
+   * cleanup.
+   *
+   * @return The random filepath to a non-existent file or folder.
+   */
+  static FilePath getRandomTempPath() noexcept;
+
+  /**
    * @brief Get the path to the cache directory
    *
    * @note This function is thread-safe.

--- a/libs/librepcb/core/fileio/filepath.cpp
+++ b/libs/librepcb/core/fileio/filepath.cpp
@@ -214,49 +214,6 @@ FilePath FilePath::fromRelative(const FilePath& base,
   return FilePath(base.mFileInfo.filePath() % QLatin1Char('/') % relative);
 }
 
-FilePath FilePath::getApplicationTempPath() noexcept {
-  auto detect = []() {
-    // Use different temporary directory if supplied by environment variable
-    // "LIBREPCB_TEMP_DIR" (e.g. for deployment). However, this is just a
-    // safety fallback which is not communicated publicly. If no problems occur
-    // with the default temp path, we should remove this fallback some day.
-    FilePath fp(qgetenv("LIBREPCB_TEMP_DIR"));
-    if (fp.isValid()) {
-      return fp;
-    }
-
-    // Note: Temporary directory has to be per-user, see
-    // https://github.com/LibrePCB/LibrePCB/issues/1871.
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)  // UNIX/Linux
-    // QStandardPaths::RuntimeLocation is a per-user directory on UNIX systems.
-    fp.setPath(
-        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation));
-#else
-    // QStandardPaths::RuntimeLocation cannot be used on macOS/Windows since
-    // it would return a really strange/wrong directory. However,
-    // QStandardPaths::TempLocation is a per-user directory on those systems,
-    // so we can use it instead.
-    fp.setPath(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
-#endif
-    if (!fp.isValid()) {
-      qCritical() << "Could not determine the system's temporary directory!";
-    }
-    return fp.getPathTo("LibrePCB");
-  };
-
-  static const FilePath value = detect();
-  return value;
-}
-
-FilePath FilePath::getRandomTempPath() noexcept {
-  // Attention: This pattern is assumed by
-  // Application::cleanTemporaryDirectory() to detect the age of tmp files!
-  QString random = QString("%1_%2")
-                       .arg(QDateTime::currentMSecsSinceEpoch())
-                       .arg(QRandomGenerator::global()->generate());
-  return getApplicationTempPath().getPathTo(random);
-}
-
 QString FilePath::cleanFileName(const QString& userInput,
                                 CleanFileNameOptions options,
                                 int maxLength) noexcept {

--- a/libs/librepcb/core/fileio/filepath.cpp
+++ b/libs/librepcb/core/fileio/filepath.cpp
@@ -214,17 +214,38 @@ FilePath FilePath::fromRelative(const FilePath& base,
   return FilePath(base.mFileInfo.filePath() % QLatin1Char('/') % relative);
 }
 
-FilePath FilePath::getTempPath() noexcept {
-  FilePath tmp(QDir::tempPath());
-
-  if (!tmp.isExistingDir())
-    qWarning() << "Could not determine the system's temporary directory!";
-
-  return tmp;
-}
-
 FilePath FilePath::getApplicationTempPath() noexcept {
-  return getTempPath().getPathTo("librepcb");
+  auto detect = []() {
+    // Use different temporary directory if supplied by environment variable
+    // "LIBREPCB_TEMP_DIR" (e.g. for deployment). However, this is just a
+    // safety fallback which is not communicated publicly. If no problems occur
+    // with the default temp path, we should remove this fallback some day.
+    FilePath fp(qgetenv("LIBREPCB_TEMP_DIR"));
+    if (fp.isValid()) {
+      return fp;
+    }
+
+    // Note: Temporary directory has to be per-user, see
+    // https://github.com/LibrePCB/LibrePCB/issues/1871.
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)  // UNIX/Linux
+    // QStandardPaths::RuntimeLocation is a per-user directory on UNIX systems.
+    fp.setPath(
+        QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation));
+#else
+    // QStandardPaths::RuntimeLocation cannot be used on macOS/Windows since
+    // it would return a really strange/wrong directory. However,
+    // QStandardPaths::TempLocation is a per-user directory on those systems,
+    // so we can use it instead.
+    fp.setPath(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+#endif
+    if (!fp.isValid()) {
+      qCritical() << "Could not determine the system's temporary directory!";
+    }
+    return fp.getPathTo("LibrePCB");
+  };
+
+  static const FilePath value = detect();
+  return value;
 }
 
 FilePath FilePath::getRandomTempPath() noexcept {

--- a/libs/librepcb/core/fileio/filepath.h
+++ b/libs/librepcb/core/fileio/filepath.h
@@ -371,44 +371,6 @@ public:  // Methods
                                const QString& relative) noexcept;
 
   /**
-   * @brief Get the path to the application's temporary directory
-   *
-   * Typically returned paths:
-   *
-   * - Windows: `C:/Users/$USER/AppData/Local/Temp/LibrePCB`
-   * - MacOS: Random, e.g.
-   *   `/private/var/folders/g3/pffjr_y96bq06blnkf72x_hw0000gn/T/LibrePCB`
-   * - Linux:
-   *   - `$XDG_RUNTIME_DIR/LibrePCB` -> `/run/user/$USER/LibrePCB`
-   *   - `$TMPDIR/runtime-$USER/LibrePCB` -> `/tmp/runtime-$USER/LibrePCB`
-   *   - `/tmp/runtime-$USER/LibrePCB`
-   *
-   * @note This function is thread-safe.
-   *
-   * @attention Do not use this to store any files in it!
-   *            Use #getRandomTempPath() instead.
-   *
-   * @return Guaranteed valid file path to a librepcb-specific directory
-   *         for the current user (i.e. this temp dir is neither shared
-   *         between applications, not shared between users). However, the
-   *         directory may not exist (yet).
-   */
-  static FilePath getApplicationTempPath() noexcept;
-
-  /**
-   * @brief Get a random temporary file path
-   *
-   * This will return a path inside the directory #getApplicationTempPath(),
-   * which then can be used to create a temporary file or folder. The random
-   * name follows the pattern `<UNIX_TIMESTAMP_MS>_<RANDOM_NUMBER>` as required
-   * by ::librepcb::Application::cleanTemporaryDirectory() for the automatic
-   * cleanup.
-   *
-   * @return The random filepath to a non-existent file or folder.
-   */
-  static FilePath getRandomTempPath() noexcept;
-
-  /**
    * @brief Clean a given string so that it becomes a valid filename
    *
    * Every time a file- or directory name needs to be constructed (e.g. from

--- a/libs/librepcb/core/fileio/filepath.h
+++ b/libs/librepcb/core/fileio/filepath.h
@@ -371,30 +371,40 @@ public:  // Methods
                                const QString& relative) noexcept;
 
   /**
-   * @brief Get the path to the temporary directory (e.g. "/tmp" on Unix/Linux)
+   * @brief Get the path to the application's temporary directory
+   *
+   * Typically returned paths:
+   *
+   * - Windows: `C:/Users/$USER/AppData/Local/Temp/LibrePCB`
+   * - MacOS: Random, e.g.
+   *   `/private/var/folders/g3/pffjr_y96bq06blnkf72x_hw0000gn/T/LibrePCB`
+   * - Linux:
+   *   - `$XDG_RUNTIME_DIR/LibrePCB` -> `/run/user/$USER/LibrePCB`
+   *   - `$TMPDIR/runtime-$USER/LibrePCB` -> `/tmp/runtime-$USER/LibrePCB`
+   *   - `/tmp/runtime-$USER/LibrePCB`
+   *
+   * @note This function is thread-safe.
    *
    * @attention Do not use this to store any files in it!
    *            Use #getRandomTempPath() instead.
    *
-   * @return The filepath (in case of an error, the path can be invalid!)
-   */
-  static FilePath getTempPath() noexcept;
-
-  /**
-   * @brief Get the path to the temporary application directory (e.g.
-   * "/tmp/librepcb")
-   *
-   * @attention Do not use this to store any files in it!
-   *            Use #getRandomTempPath() instead.
-   *
-   * @return The filepath (in case of an error, the path can be invalid!)
+   * @return Guaranteed valid file path to a librepcb-specific directory
+   *         for the current user (i.e. this temp dir is neither shared
+   *         between applications, not shared between users). However, the
+   *         directory may not exist (yet).
    */
   static FilePath getApplicationTempPath() noexcept;
 
   /**
-   * @brief Get a random temporary directory path (e.g. "/tmp/librepcb/42")
+   * @brief Get a random temporary file path
    *
-   * @return The random filepath (in case of an error, the path can be invalid!)
+   * This will return a path inside the directory #getApplicationTempPath(),
+   * which then can be used to create a temporary file or folder. The random
+   * name follows the pattern `<UNIX_TIMESTAMP_MS>_<RANDOM_NUMBER>` as required
+   * by ::librepcb::Application::cleanTemporaryDirectory() for the automatic
+   * cleanup.
+   *
+   * @return The random filepath to a non-existent file or folder.
    */
   static FilePath getRandomTempPath() noexcept;
 

--- a/libs/librepcb/core/fileio/transactionaldirectory.cpp
+++ b/libs/librepcb/core/fileio/transactionaldirectory.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "transactionaldirectory.h"
 
+#include "../application.h"
 #include "transactionalfilesystem.h"
 
 /*******************************************************************************
@@ -36,7 +37,8 @@ namespace librepcb {
 TransactionalDirectory::TransactionalDirectory(QObject* parent)
   : FileSystem(parent),
     // Open file system in read-only mode to avoid creating ".lock" file!
-    mFileSystem(TransactionalFileSystem::openRO(FilePath::getRandomTempPath())),
+    mFileSystem(
+        TransactionalFileSystem::openRO(Application::getRandomTempPath())),
     mPath() {
 }
 

--- a/libs/librepcb/core/project/outputjobrunner.cpp
+++ b/libs/librepcb/core/project/outputjobrunner.cpp
@@ -762,7 +762,7 @@ void OutputJobRunner::runImpl(const ArchiveOutputJob& job) {
 
   // Collect input files.
   std::shared_ptr<TransactionalFileSystem> fs =
-      TransactionalFileSystem::openRW(FilePath::getRandomTempPath());
+      TransactionalFileSystem::openRW(Application::getRandomTempPath());
   for (auto it = job.getInputJobs().begin(); it != job.getInputJobs().end();
        ++it) {
     if (!mWriter->getWrittenFiles().contains(it.key())) {

--- a/libs/librepcb/editor/guiapplication.cpp
+++ b/libs/librepcb/editor/guiapplication.cpp
@@ -610,7 +610,7 @@ std::shared_ptr<ProjectEditor> GuiApplication::openProject(
     QString projectFileName = fp.getFilename();
     if (fp.getSuffix() == "lppz") {
       fs = TransactionalFileSystem::openRO(
-          FilePath::getRandomTempPath(),
+          Application::getRandomTempPath(),
           &TransactionalFileSystem::RestoreMode::no);
       fs->removeDirRecursively();  // 1) Get a clean initial state.
       fs->loadFromZip(fp);  // 2) Load files from ZIP.

--- a/libs/librepcb/editor/library/org/organizationtab.cpp
+++ b/libs/librepcb/editor/library/org/organizationtab.cpp
@@ -36,6 +36,7 @@
 #include "../libraryeditor.h"
 #include "organizationpcbdesignrulesmodel.h"
 
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
@@ -484,7 +485,7 @@ void OrganizationTab::execOutputJobsDialog(
 
 Project& OrganizationTab::getTmpProject() {
   if (!mTmpProject) {
-    auto fs = TransactionalFileSystem::openRO(FilePath::getRandomTempPath());
+    auto fs = TransactionalFileSystem::openRO(Application::getRandomTempPath());
     mTmpProject = Project::create(std::make_unique<TransactionalDirectory>(fs),
                                   "tmp.lpp");
   }

--- a/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
+++ b/libs/librepcb/editor/library/sym/symbolclipboarddata.cpp
@@ -51,7 +51,8 @@ namespace editor {
 
 SymbolClipboardData::SymbolClipboardData(const Uuid& symbolUuid,
                                          const Point& cursorPos) noexcept
-  : mFileSystem(TransactionalFileSystem::openRW(FilePath::getRandomTempPath())),
+  : mFileSystem(
+        TransactionalFileSystem::openRW(Application::getRandomTempPath())),
     mSymbolUuid(symbolUuid),
     mCursorPos(cursorPos) {
 }

--- a/libs/librepcb/editor/project/board/boardclipboarddata.cpp
+++ b/libs/librepcb/editor/project/board/boardclipboarddata.cpp
@@ -44,7 +44,8 @@ namespace editor {
 
 BoardClipboardData::BoardClipboardData(const Uuid& boardUuid,
                                        const Point& cursorPos) noexcept
-  : mFileSystem(TransactionalFileSystem::openRW(FilePath::getRandomTempPath())),
+  : mFileSystem(
+        TransactionalFileSystem::openRW(Application::getRandomTempPath())),
     mBoardUuid(boardUuid),
     mCursorPos(cursorPos),
     mDevices(),

--- a/libs/librepcb/editor/project/projectreadmerenderer.cpp
+++ b/libs/librepcb/editor/project/projectreadmerenderer.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 #include "projectreadmerenderer.h"
 
+#include <librepcb/core/application.h>
 #include <librepcb/core/exceptions.h>
 #include <librepcb/core/fileio/filepath.h>
 #include <librepcb/core/fileio/fileutils.h>
@@ -110,7 +111,7 @@ void ProjectReadmeRenderer::start() noexcept {
 QPixmap ProjectReadmeRenderer::render(const FilePath& fp, int width) noexcept {
   try {
     // Create temporary directory.
-    const FilePath tmpDir = FilePath::getRandomTempPath();
+    const FilePath tmpDir = Application::getRandomTempPath();
     auto sg =
         scopeGuard([tmpDir]() { QDir(tmpDir.toStr()).removeRecursively(); });
 

--- a/libs/librepcb/editor/project/schematic/schematicclipboarddata.cpp
+++ b/libs/librepcb/editor/project/schematic/schematicclipboarddata.cpp
@@ -45,7 +45,8 @@ namespace editor {
 SchematicClipboardData::SchematicClipboardData(
     const Uuid& schematicUuid, const Point& cursorPos,
     const AssemblyVariantList& assemblyVariants) noexcept
-  : mFileSystem(TransactionalFileSystem::openRW(FilePath::getRandomTempPath())),
+  : mFileSystem(
+        TransactionalFileSystem::openRW(Application::getRandomTempPath())),
     mSchematicUuid(schematicUuid),
     mCursorPos(cursorPos),
     mAssemblyVariants(assemblyVariants),

--- a/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizardcontext.cpp
+++ b/libs/librepcb/editor/workspace/initializeworkspacewizard/initializeworkspacewizardcontext.cpp
@@ -126,9 +126,9 @@ void InitializeWorkspaceWizardContext::installExampleProjects() const noexcept {
   foreach (const auto& project, projects) {
     const FilePath dst = dir.getPathTo(project.first);
     if (!dst.isExistingDir()) {
-      FileDownload* dl =
-          new FileDownload(QUrl(project.second), FilePath::getRandomTempPath(),
-                           std::make_shared<QSemaphore>(1));
+      FileDownload* dl = new FileDownload(QUrl(project.second),
+                                          Application::getRandomTempPath(),
+                                          std::make_shared<QSemaphore>(1));
       dl->setZipExtractionDirectory(dst);
       QGuiApplication::setOverrideCursor(Qt::WaitCursor);
       connect(dl, &FileDownload::finished, qApp,

--- a/tests/unittests/core/3d/occmodeltest.cpp
+++ b/tests/unittests/core/3d/occmodeltest.cpp
@@ -23,6 +23,7 @@
 #include <Standard_Version.hxx>
 #include <gtest/gtest.h>
 #include <librepcb/core/3d/occmodel.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/exceptions.h>
 #include <librepcb/core/fileio/filepath.h>
 #include <librepcb/core/fileio/fileutils.h>
@@ -183,7 +184,8 @@ TEST_F(OccModelTest, testBuildAndSaveAssembly) {
       Transform(Point(Length(10000), Length(20000)), Angle::deg45(), true),
       "X2");
 
-  const FilePath outFp = FilePath::getRandomTempPath().getPathTo("te st.step");
+  const FilePath outFp =
+      Application::getRandomTempPath().getPathTo("te st.step");
   assembly->saveAsStep("PCB Assembly", outFp);
 
   // Read back.

--- a/tests/unittests/core/applicationtest.cpp
+++ b/tests/unittests/core/applicationtest.cpp
@@ -67,6 +67,25 @@ TEST_F(ApplicationTest, testBuildFullVersionDetails) {
   EXPECT_GE(s.split("\n").count(), 5);
 }
 
+TEST_F(ApplicationTest, testGetTempDir) {
+  const FilePath fp = Application::getTempDir();
+  std::cout << qPrintable(fp.toStr()) << std::endl;
+  EXPECT_TRUE(fp.isValid());
+}
+
+TEST_F(ApplicationTest, testGetRandomTempPath) {
+  const FilePath fp = Application::getRandomTempPath();
+  EXPECT_TRUE(fp.isLocatedInDir(Application::getTempDir()));
+
+  // Test if we can create a file.
+  FileUtils::writeFile(fp, "test");
+  FileUtils::removeFile(fp);
+
+  // Test if we can create a folder.
+  FileUtils::makePath(fp);
+  FileUtils::removeDirRecursively(fp);
+}
+
 TEST_F(ApplicationTest, testGetCacheDir) {
   // Check if the resources directory is valid and writable.
   EXPECT_TRUE(Application::getCacheDir().isValid());

--- a/tests/unittests/core/export/graphicsexporttest.cpp
+++ b/tests/unittests/core/export/graphicsexporttest.cpp
@@ -20,10 +20,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include "graphicsexporttest.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/export/graphicsexport.h>
 
 #include <QtCore>
@@ -44,7 +44,7 @@ public:
   FilePath mOutputDir;
   QVector<FilePath> mSavedFiles;  // From signal savingFile().
 
-  GraphicsExportTest() : mOutputDir(FilePath::getRandomTempPath()) {
+  GraphicsExportTest() : mOutputDir(Application::getRandomTempPath()) {
     QSettings().clear();
   }
 

--- a/tests/unittests/core/fileio/asynccopyoperationtest.cpp
+++ b/tests/unittests/core/fileio/asynccopyoperationtest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/asynccopyoperation.h>
 #include <librepcb/core/fileio/fileutils.h>
 
@@ -54,7 +54,7 @@ public:
   QObject mContext;
 
   AsyncCopyOperationTest()
-    : mTmpDir(FilePath::getRandomTempPath()),
+    : mTmpDir(Application::getRandomTempPath()),
       mNonExistingDir(mTmpDir.getPathTo("non existing")),
       mEmptyDir(mTmpDir.getPathTo("empty directory")),
       mPopulatedDir(mTmpDir.getPathTo("populated directory")),

--- a/tests/unittests/core/fileio/csvfiletest.cpp
+++ b/tests/unittests/core/fileio/csvfiletest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/exceptions.h>
 #include <librepcb/core/fileio/csvfile.h>
 #include <librepcb/core/fileio/filepath.h>
@@ -116,7 +116,7 @@ TEST_F(CsvFileTest, testSaveToFile) {
   f.addValue({"Value", "Value With Space", "With,Comma", "\"With Quotes\""});
   f.addValue({"-1.2345", "Foo\r\nBar", " spaces around ", "äöü"});
 
-  FilePath fp = FilePath::getRandomTempPath();
+  FilePath fp = Application::getRandomTempPath();
   f.saveToFile(fp);
   EXPECT_EQ(
       "# Foo\n"

--- a/tests/unittests/core/fileio/directorylocktest.cpp
+++ b/tests/unittests/core/fileio/directorylocktest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/exceptions.h>
 #include <librepcb/core/fileio/directorylock.h>
 #include <librepcb/core/fileio/fileutils.h>
@@ -43,7 +43,7 @@ class DirectoryLockTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // create temporary, empty directory
-    mTempDir = FilePath::getRandomTempPath();
+    mTempDir = Application::getRandomTempPath();
     mTempLockFilePath = FilePath(mTempDir.toStr() % "/.lock");
     if (mTempDir.isExistingDir()) {
       FileUtils::removeDirRecursively(mTempDir);  // can throw

--- a/tests/unittests/core/fileio/filepathtest.cpp
+++ b/tests/unittests/core/fileio/filepathtest.cpp
@@ -23,7 +23,6 @@
 
 #include <gtest/gtest.h>
 #include <librepcb/core/fileio/filepath.h>
-#include <librepcb/core/fileio/fileutils.h>
 
 #include <QtCore>
 
@@ -153,25 +152,6 @@ TEST_P(FilePathTest, testOperatorAssign) {
   p2 = p1;
   EXPECT_EQ(p1.isValid(), p2.isValid());
   EXPECT_EQ(p1.toStr(), p2.toStr());
-}
-
-TEST(FilePathTest, testGetApplicationTempPath) {
-  const FilePath fp = FilePath::getApplicationTempPath();
-  std::cout << qPrintable(fp.toStr()) << std::endl;
-  EXPECT_TRUE(fp.isValid());
-}
-
-TEST(FilePathTest, testGetRandomTempPath) {
-  const FilePath fp = FilePath::getRandomTempPath();
-  EXPECT_TRUE(fp.isLocatedInDir(FilePath::getApplicationTempPath()));
-
-  // Test if we can create a file.
-  FileUtils::writeFile(fp, "Test");
-  FileUtils::removeFile(fp);
-
-  // Test if we can create a folder.
-  FileUtils::makePath(fp);
-  FileUtils::removeDirRecursively(fp);
 }
 
 TEST(FilePathTest, testCleanFileName) {

--- a/tests/unittests/core/fileio/filepathtest.cpp
+++ b/tests/unittests/core/fileio/filepathtest.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include <librepcb/core/fileio/filepath.h>
+#include <librepcb/core/fileio/fileutils.h>
 
 #include <QtCore>
 
@@ -56,7 +57,7 @@ class FilePathTest : public ::testing::TestWithParam<FilePathTestData> {};
  *  Test Methods
  ******************************************************************************/
 
-TEST_P(FilePathTest, testDefaultConstructor) {
+TEST(FilePathTest, testDefaultConstructor) {
   FilePath p;
   EXPECT_FALSE(p.isValid());
   EXPECT_EQ(QString(""), p.toStr());
@@ -152,6 +153,25 @@ TEST_P(FilePathTest, testOperatorAssign) {
   p2 = p1;
   EXPECT_EQ(p1.isValid(), p2.isValid());
   EXPECT_EQ(p1.toStr(), p2.toStr());
+}
+
+TEST(FilePathTest, testGetApplicationTempPath) {
+  const FilePath fp = FilePath::getApplicationTempPath();
+  std::cout << qPrintable(fp.toStr()) << std::endl;
+  EXPECT_TRUE(fp.isValid());
+}
+
+TEST(FilePathTest, testGetRandomTempPath) {
+  const FilePath fp = FilePath::getRandomTempPath();
+  EXPECT_TRUE(fp.isLocatedInDir(FilePath::getApplicationTempPath()));
+
+  // Test if we can create a file.
+  FileUtils::writeFile(fp, "Test");
+  FileUtils::removeFile(fp);
+
+  // Test if we can create a folder.
+  FileUtils::makePath(fp);
+  FileUtils::removeDirRecursively(fp);
 }
 
 TEST(FilePathTest, testCleanFileName) {

--- a/tests/unittests/core/fileio/fileutilstest.cpp
+++ b/tests/unittests/core/fileio/fileutilstest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/exceptions.h>
 #include <librepcb/core/fileio/filepath.h>
 #include <librepcb/core/fileio/fileutils.h>
@@ -62,7 +62,7 @@ static void setupFile(const FilePath& pth, const QByteArray& content,
 
 class FileUtilsTest : public ::testing::Test {
 public:
-  FilePath root{FilePath::getRandomTempPath()};
+  FilePath root{Application::getRandomTempPath()};
 
   // the sources of already existing files and directories
   FilePath rootFile{root.getPathTo("file.txt")};  // source for all operations

--- a/tests/unittests/core/fileio/transactionaldirectorytest.cpp
+++ b/tests/unittests/core/fileio/transactionaldirectorytest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 
@@ -44,14 +44,14 @@ public:
     // Open in read-only mode to avoid creating a ".lock" file which would
     // influence the tests.
     mFileSystem =
-        TransactionalFileSystem::openRO(FilePath::getRandomTempPath());
+        TransactionalFileSystem::openRO(Application::getRandomTempPath());
     mFileSystem->write("a.txt", "a");
     mFileSystem->write("a/b.txt", "b");
     mFileSystem->write("a/b/c.txt", "c");
     mFileSystem->write("a/b/c/d.txt", "d");
 
     mEmptyFileSystem =
-        TransactionalFileSystem::openRO(FilePath::getRandomTempPath());
+        TransactionalFileSystem::openRO(Application::getRandomTempPath());
   }
 
   ~TransactionalDirectoryTest() override {}
@@ -65,7 +65,7 @@ TEST_F(TransactionalDirectoryTest, testDefaultConstructorCreatesTempFs) {
   TransactionalDirectory dir;
   ASSERT_TRUE(dir.getFileSystem());
   EXPECT_TRUE(dir.getFileSystem()->getAbsPath().isLocatedInDir(
-      FilePath::getApplicationTempPath()));
+      Application::getTempDir()));
 }
 
 TEST_F(TransactionalDirectoryTest, testDefaultConstructorCreatesEmptyFs) {

--- a/tests/unittests/core/fileio/transactionalfilesystemtest.cpp
+++ b/tests/unittests/core/fileio/transactionalfilesystemtest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/fileio/ziparchive.h>
@@ -46,7 +46,7 @@ public:
 
   TransactionalFileSystemTest() {
     // temporary dir (with spaces in path to make tests harder)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo("spaces in path");
+    mTmpDir = Application::getRandomTempPath().getPathTo("spaces in path");
     FileUtils::writeFile(mTmpDir.getPathTo("1.txt"), "1");
 
     // non-existing dir

--- a/tests/unittests/core/fileio/zipwriterziparchivetest.cpp
+++ b/tests/unittests/core/fileio/zipwriterziparchivetest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/exceptions.h>
 #include <librepcb/core/fileio/filepath.h>
 #include <librepcb/core/fileio/fileutils.h>
@@ -46,7 +46,7 @@ public:
   FilePath mZipFilePath;
 
   ZipWriterZipArchiveTest()
-    : mTmpDir(FilePath::getRandomTempPath()),
+    : mTmpDir(Application::getRandomTempPath()),
       mZipFilePath(mTmpDir.getPathTo("test file.zip")) {}
   ~ZipWriterZipArchiveTest() override {
     QDir(mTmpDir.toStr()).removeRecursively();

--- a/tests/unittests/core/import/dxfreadertest.cpp
+++ b/tests/unittests/core/import/dxfreadertest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/import/dxfreader.h>
 #include <librepcb/core/serialization/sexpression.h>
@@ -43,7 +44,7 @@ protected:
    * @brief Helper to call reader.parse() with DXF content as bytearray
    */
   void parse(const QByteArray& dxf) {
-    FilePath fp = FilePath::getRandomTempPath();
+    FilePath fp = Application::getRandomTempPath();
     FileUtils::writeFile(fp, dxf);
     reader.parse(fp);
     FileUtils::removeFile(fp);
@@ -75,7 +76,7 @@ protected:
  ******************************************************************************/
 
 TEST_F(DxfReaderTest, testInexistentFileThrowsRuntimeError) {
-  FilePath fp = FilePath::getRandomTempPath();
+  FilePath fp = Application::getRandomTempPath();
   EXPECT_THROW(reader.parse(fp), RuntimeError);
 }
 

--- a/tests/unittests/core/library/cmp/componenttest.cpp
+++ b/tests/unittests/core/library/cmp/componenttest.cpp
@@ -47,7 +47,7 @@ public:
 
   ComponentTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo(sUuid);
+    mTmpDir = Application::getRandomTempPath().getPathTo(sUuid);
   }
 
   ~ComponentTest() override {

--- a/tests/unittests/core/library/cmpcat/componentcategorytest.cpp
+++ b/tests/unittests/core/library/cmpcat/componentcategorytest.cpp
@@ -47,7 +47,7 @@ public:
 
   ComponentCategoryTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo(sUuid);
+    mTmpDir = Application::getRandomTempPath().getPathTo(sUuid);
   }
 
   ~ComponentCategoryTest() override {

--- a/tests/unittests/core/library/dev/devicetest.cpp
+++ b/tests/unittests/core/library/dev/devicetest.cpp
@@ -47,7 +47,7 @@ public:
 
   DeviceTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo(sUuid);
+    mTmpDir = Application::getRandomTempPath().getPathTo(sUuid);
   }
 
   ~DeviceTest() override {

--- a/tests/unittests/core/library/librarybaseelementtest.cpp
+++ b/tests/unittests/core/library/librarybaseelementtest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/library/librarybaseelement.h>
@@ -43,7 +44,7 @@ public:
   QScopedPointer<LibraryBaseElement> mNewElement;
 
   LibraryBaseElementTest() {
-    mTempDir = FilePath::getRandomTempPath();
+    mTempDir = Application::getRandomTempPath();
 
     mNewElement.reset(new LibraryBaseElement(
         "sym", "symbol", Uuid::createRandom(), Version::fromString("1.0"),

--- a/tests/unittests/core/library/librarytest.cpp
+++ b/tests/unittests/core/library/librarytest.cpp
@@ -46,7 +46,7 @@ public:
 
   LibraryTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo("test dir.lplib");
+    mTmpDir = Application::getRandomTempPath().getPathTo("test dir.lplib");
   }
 
   ~LibraryTest() override {

--- a/tests/unittests/core/library/pkg/packagetest.cpp
+++ b/tests/unittests/core/library/pkg/packagetest.cpp
@@ -47,7 +47,7 @@ public:
 
   PackageTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo(sUuid);
+    mTmpDir = Application::getRandomTempPath().getPathTo(sUuid);
   }
 
   ~PackageTest() override {

--- a/tests/unittests/core/library/pkgcat/packagecategorytest.cpp
+++ b/tests/unittests/core/library/pkgcat/packagecategorytest.cpp
@@ -47,7 +47,7 @@ public:
 
   PackageCategoryTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo(sUuid);
+    mTmpDir = Application::getRandomTempPath().getPathTo(sUuid);
   }
 
   ~PackageCategoryTest() override {

--- a/tests/unittests/core/library/sym/symboltest.cpp
+++ b/tests/unittests/core/library/sym/symboltest.cpp
@@ -47,7 +47,7 @@ public:
 
   SymbolTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mTmpDir = FilePath::getRandomTempPath().getPathTo(sUuid);
+    mTmpDir = Application::getRandomTempPath().getPathTo(sUuid);
   }
 
   ~SymbolTest() override {

--- a/tests/unittests/core/network/filedownloadtest.cpp
+++ b/tests/unittests/core/network/filedownloadtest.cpp
@@ -23,6 +23,7 @@
 #include "networkrequestbasesignalreceiver.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/network/filedownload.h>
 #include <librepcb/core/network/networkaccessmanager.h>
@@ -58,7 +59,7 @@ public:
   NetworkRequestBaseSignalReceiver mSignalReceiver;
   static NetworkAccessManager* sDownloadManager;
 
-  FileDownloadTest() : mTmpDir(FilePath::getRandomTempPath()) {}
+  FileDownloadTest() : mTmpDir(Application::getRandomTempPath()) {}
 
   ~FileDownloadTest() override { QDir(mTmpDir.toStr()).removeRecursively(); }
 

--- a/tests/unittests/core/project/outputjobrunnertest.cpp
+++ b/tests/unittests/core/project/outputjobrunnertest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
@@ -52,7 +53,7 @@ class OutputJobRunnerTest : public ::testing::Test {
 public:
   FilePath mOutDir;
 
-  OutputJobRunnerTest() { mOutDir = FilePath::getRandomTempPath(); }
+  OutputJobRunnerTest() { mOutDir = Application::getRandomTempPath(); }
 
   ~OutputJobRunnerTest() override { QDir(mOutDir.toStr()).removeRecursively(); }
 
@@ -85,7 +86,7 @@ public:
   std::unique_ptr<Project> createProject() const {
     std::unique_ptr<Project> project = Project::create(
         std::make_unique<TransactionalDirectory>(
-            TransactionalFileSystem::openRW(FilePath::getRandomTempPath())),
+            TransactionalFileSystem::openRW(Application::getRandomTempPath())),
         "project.lpp");
     return project;
   }

--- a/tests/unittests/core/project/projectjsonexporttest.cpp
+++ b/tests/unittests/core/project/projectjsonexporttest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/geometry/polygon.h>
 #include <librepcb/core/project/board/board.h>
@@ -68,7 +69,7 @@ protected:
   std::unique_ptr<Project> createProject() const {
     std::unique_ptr<Project> project = Project::create(
         std::make_unique<TransactionalDirectory>(
-            TransactionalFileSystem::openRW(FilePath::getRandomTempPath())),
+            TransactionalFileSystem::openRW(Application::getRandomTempPath())),
         "project.lpp");
     project->setUuid(Uuid::fromString("7b3985b2-91ad-4e93-8d15-7668869ed45d"));
     project->setName(ElementName("New Project"));

--- a/tests/unittests/core/project/projectlibrarytest.cpp
+++ b/tests/unittests/core/project/projectlibrarytest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/library/sym/symbol.h>
@@ -53,7 +54,7 @@ public:
   qint64 mNewSymbolCreationSize;
 
   ProjectLibraryTest() {
-    mTempDir = FilePath::getRandomTempPath();
+    mTempDir = Application::getRandomTempPath();
     mLibDir = mTempDir.getPathTo("project library test");
     mTempFs = TransactionalFileSystem::openRW(mTempDir);
     mLibFs = TransactionalFileSystem::openRW(mLibDir);

--- a/tests/unittests/core/project/projecttest.cpp
+++ b/tests/unittests/core/project/projecttest.cpp
@@ -50,7 +50,8 @@ public:
 
   ProjectTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mProjectDir = FilePath::getRandomTempPath().getPathTo("test project dir");
+    mProjectDir =
+        Application::getRandomTempPath().getPathTo("test project dir");
     mProjectFile = mProjectDir.getPathTo("test project.lpp");
     mLogsDir = mProjectDir.getPathTo("logs");
   }

--- a/tests/unittests/core/sqlitedatabasetest.cpp
+++ b/tests/unittests/core/sqlitedatabasetest.cpp
@@ -20,8 +20,8 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/exceptions.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/sqlitedatabase.h>
@@ -43,7 +43,7 @@ class SQLiteDatabaseTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // create temporary, empty directory
-    mTempDir = FilePath::getRandomTempPath();
+    mTempDir = Application::getRandomTempPath();
     mTempDbFilePath = mTempDir.getPathTo("db.sqlite");
     if (mTempDir.isExistingDir()) {
       FileUtils::removeDirRecursively(mTempDir);  // can throw

--- a/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
+++ b/tests/unittests/core/workspace/workspacelibrarydbtest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/library/cat/componentcategory.h>
 #include <librepcb/core/library/cat/packagecategory.h>
@@ -55,7 +56,7 @@ public:
   std::unique_ptr<SQLiteDatabase> mDb;
   std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
 
-  WorkspaceLibraryDbTest() : mWsDir(FilePath::getRandomTempPath()) {
+  WorkspaceLibraryDbTest() : mWsDir(Application::getRandomTempPath()) {
     FileUtils::makePath(mWsDir);
     mWsDb = std::make_unique<WorkspaceLibraryDb>(mWsDir);
     mDb = std::make_unique<SQLiteDatabase>(mWsDb->getFilePath());

--- a/tests/unittests/core/workspace/workspacetest.cpp
+++ b/tests/unittests/core/workspace/workspacetest.cpp
@@ -49,7 +49,7 @@ public:
 
   WorkspaceTest() {
     // the whitespaces in the path are there to make the test even stronger ;)
-    mWsDir = FilePath::getRandomTempPath().getPathTo("test workspace dir");
+    mWsDir = Application::getRandomTempPath().getPathTo("test workspace dir");
     mVersionFile = mWsDir.getPathTo(".librepcb-workspace");
     mProjectsPath = mWsDir.getPathTo("projects");
     mDataPath = mWsDir.getPathTo("data");

--- a/tests/unittests/eagleimport/eaglelibraryimporttest.cpp
+++ b/tests/unittests/eagleimport/eaglelibraryimporttest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/utils/messagelogger.h>
 #include <librepcb/eagleimport/eaglelibraryimport.h>
 
@@ -45,7 +46,7 @@ class EagleLibraryImportTest : public ::testing::Test {};
 
 TEST_F(EagleLibraryImportTest, testImport) {
   FilePath src(TEST_DATA_DIR "/unittests/eagleimport/resistor.lbr");
-  FilePath dst = FilePath::getRandomTempPath();
+  FilePath dst = Application::getRandomTempPath();
 
   EagleLibraryImport import(dst);
 

--- a/tests/unittests/eagleimport/eagleprojectimporttest.cpp
+++ b/tests/unittests/eagleimport/eagleprojectimporttest.cpp
@@ -23,6 +23,7 @@
 #include "../testhelpers.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/filepath.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
@@ -54,7 +55,7 @@ class EagleProjectImportTest : public ::testing::Test {
 public:
   FilePath mTmpDir;
 
-  EagleProjectImportTest() : mTmpDir(FilePath::getRandomTempPath()) {}
+  EagleProjectImportTest() : mTmpDir(Application::getRandomTempPath()) {}
 
   ~EagleProjectImportTest() override {
     QDir(mTmpDir.toStr()).removeRecursively();

--- a/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
+++ b/tests/unittests/editor/dialogs/graphicsexportdialogtest.cpp
@@ -20,11 +20,11 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include "../../core/export/graphicsexporttest.h"
 #include "../../testhelpers.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/export/graphicsexport.h>
 #include <librepcb/core/export/graphicsexportsettings.h>
 #include <librepcb/core/fileio/filepath.h>
@@ -57,7 +57,7 @@ public:
   FilePath mOutputDir;
   QVector<FilePath> mRequestedFilesToOpen;  // From signal requestOpenFile().
 
-  GraphicsExportDialogTest() : mOutputDir(FilePath::getRandomTempPath()) {
+  GraphicsExportDialogTest() : mOutputDir(Application::getRandomTempPath()) {
     QSettings().clear();
   }
 

--- a/tests/unittests/editor/library/cat/categorytreebuildertest.cpp
+++ b/tests/unittests/editor/library/cat/categorytreebuildertest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/library/cat/componentcategory.h>
 #include <librepcb/core/library/cat/packagecategory.h>
@@ -51,7 +52,7 @@ public:
   std::unique_ptr<SQLiteDatabase> mDb;
   std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
 
-  CategoryTreeBuilderTest() : mWsDir(FilePath::getRandomTempPath()) {
+  CategoryTreeBuilderTest() : mWsDir(Application::getRandomTempPath()) {
     FileUtils::makePath(mWsDir);
     mWsDb = std::make_unique<WorkspaceLibraryDb>(mWsDir);
     mDb = std::make_unique<SQLiteDatabase>(mWsDb->getFilePath());

--- a/tests/unittests/editor/library/cmd/cmdpackagereloadtest.cpp
+++ b/tests/unittests/editor/library/cmd/cmdpackagereloadtest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
@@ -43,7 +44,7 @@ namespace tests {
 class CmdPackageReloadTest : public ::testing::Test {
 public:
   FilePath mTmpDir;
-  CmdPackageReloadTest() : mTmpDir(FilePath::getRandomTempPath()) {}
+  CmdPackageReloadTest() : mTmpDir(Application::getRandomTempPath()) {}
   ~CmdPackageReloadTest() override {
     QDir(mTmpDir.toStr()).removeRecursively();
   }

--- a/tests/unittests/editor/library/cmd/cmdsymbolreloadtest.cpp
+++ b/tests/unittests/editor/library/cmd/cmdsymbolreloadtest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
@@ -43,7 +44,7 @@ namespace tests {
 class CmdSymbolReloadTest : public ::testing::Test {
 public:
   FilePath mTmpDir;
-  CmdSymbolReloadTest() : mTmpDir(FilePath::getRandomTempPath()) {}
+  CmdSymbolReloadTest() : mTmpDir(Application::getRandomTempPath()) {}
   ~CmdSymbolReloadTest() override { QDir(mTmpDir.toStr()).removeRecursively(); }
 };
 

--- a/tests/unittests/editor/library/librarydownloadtest.cpp
+++ b/tests/unittests/editor/library/librarydownloadtest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
 #include <librepcb/core/network/networkaccessmanager.h>
@@ -64,7 +65,7 @@ NetworkAccessManager* LibraryDownloadTest::sDownloadManager = nullptr;
 
 TEST_F(LibraryDownloadTest, testDownloadInvalidLibrary) {
   // create temporary directory
-  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstDir = Application::getRandomTempPath();
   FilePath dstLibDir = dstDir.getPathTo("my library");
   FileUtils::makePath(dstDir);
 
@@ -97,7 +98,7 @@ TEST_F(LibraryDownloadTest, testDownloadInvalidLibrary) {
 
 TEST_F(LibraryDownloadTest, testDownloadValidLibrary) {
   // create temporary directory
-  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstDir = Application::getRandomTempPath();
   FilePath dstLibDir = dstDir.getPathTo("my library");
   FileUtils::makePath(dstDir);
 
@@ -132,7 +133,7 @@ TEST_F(LibraryDownloadTest, testDownloadValidLibrary) {
 
 TEST_F(LibraryDownloadTest, testDownloadValidNestedLibrary) {
   // create temporary directory
-  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstDir = Application::getRandomTempPath();
   FilePath dstLibDir = dstDir.getPathTo("my library");
   FileUtils::makePath(dstDir);
 
@@ -169,7 +170,7 @@ TEST_F(LibraryDownloadTest, testDownloadValidNestedLibrary) {
 
 TEST_F(LibraryDownloadTest, testDownloadValidLibraryDestinationAlreadyExists) {
   // create temporary directory
-  FilePath dstDir = FilePath::getRandomTempPath();
+  FilePath dstDir = Application::getRandomTempPath();
   FilePath dstLibDir = dstDir.getPathTo("my library");
   FileUtils::makePath(dstDir);
 

--- a/tests/unittests/editor/project/addcomponentdialogtest.cpp
+++ b/tests/unittests/editor/project/addcomponentdialogtest.cpp
@@ -20,10 +20,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include "../../testhelpers.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/fileio/transactionaldirectory.h>
 #include <librepcb/core/fileio/transactionalfilesystem.h>
@@ -61,7 +61,7 @@ public:
   std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
   std::shared_ptr<TransactionalFileSystem> mFs;
 
-  AddComponentDialogTest() : mWsDir(FilePath::getRandomTempPath()) {
+  AddComponentDialogTest() : mWsDir(Application::getRandomTempPath()) {
     QSettings().clear();
     FileUtils::makePath(mWsDir);
     mWsDb = std::make_unique<WorkspaceLibraryDb>(mWsDir);

--- a/tests/unittests/editor/utils/shortcutsreferencegeneratortest.cpp
+++ b/tests/unittests/editor/utils/shortcutsreferencegeneratortest.cpp
@@ -20,10 +20,10 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-
 #include "../../testhelpers.h"
 
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/filepath.h>
 #include <librepcb/editor/editorcommandset.h>
 #include <librepcb/editor/utils/shortcutsreferencegenerator.h>
@@ -48,7 +48,7 @@ class ShortcutsReferenceGeneratorTest : public ::testing::Test {};
  ******************************************************************************/
 
 TEST_F(ShortcutsReferenceGeneratorTest, testExportPdfMultipleTimes) {
-  FilePath fp = FilePath::getRandomTempPath().getPathTo("test.pdf");
+  FilePath fp = Application::getRandomTempPath().getPathTo("test.pdf");
   ShortcutsReferenceGenerator gen(EditorCommandSet::instance());
   EXPECT_TRUE(gen.generatePdf(fp)) << "Page layout overflow!";
   EXPECT_TRUE(fp.isExistingFile());

--- a/tests/unittests/editor/workspace/categorytreemodellegacytest.cpp
+++ b/tests/unittests/editor/workspace/categorytreemodellegacytest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/library/cat/componentcategory.h>
 #include <librepcb/core/library/cat/packagecategory.h>
@@ -57,7 +58,7 @@ public:
   std::unique_ptr<SQLiteDatabase> mDb;
   std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
 
-  CategoryTreeModelLegacyTest() : mWsDir(FilePath::getRandomTempPath()) {
+  CategoryTreeModelLegacyTest() : mWsDir(Application::getRandomTempPath()) {
     FileUtils::makePath(mWsDir);
     mWsDb = std::make_unique<WorkspaceLibraryDb>(mWsDir);
     mDb = std::make_unique<SQLiteDatabase>(mWsDb->getFilePath());

--- a/tests/unittests/editor/workspace/categorytreemodeltest.cpp
+++ b/tests/unittests/editor/workspace/categorytreemodeltest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/library/cat/componentcategory.h>
 #include <librepcb/core/library/cat/packagecategory.h>
@@ -63,7 +64,7 @@ public:
   std::unique_ptr<WorkspaceLibraryDbWriter> mWriter;
   std::unique_ptr<WorkspaceSettings> mSettings;
 
-  CategoryTreeModelTest() : mWsDir(FilePath::getRandomTempPath()) {
+  CategoryTreeModelTest() : mWsDir(Application::getRandomTempPath()) {
     FileUtils::makePath(mWsDir);
     mWsDb = std::make_unique<WorkspaceLibraryDb>(mWsDir);
     mDb = std::make_unique<SQLiteDatabase>(mWsDb->getFilePath());

--- a/tests/unittests/kicadimport/kicadlibraryimporttest.cpp
+++ b/tests/unittests/kicadimport/kicadlibraryimporttest.cpp
@@ -21,6 +21,7 @@
  *  Includes
  ******************************************************************************/
 #include <gtest/gtest.h>
+#include <librepcb/core/application.h>
 #include <librepcb/core/fileio/fileutils.h>
 #include <librepcb/core/utils/messagelogger.h>
 #include <librepcb/core/workspace/workspacelibrarydb.h>
@@ -46,7 +47,7 @@ public:
   FilePath mWsDir;
   std::unique_ptr<WorkspaceLibraryDb> mWsDb;
 
-  KiCadLibraryImportTest() : mWsDir(FilePath::getRandomTempPath()) {
+  KiCadLibraryImportTest() : mWsDir(Application::getRandomTempPath()) {
     FileUtils::makePath(mWsDir);
     mWsDb = std::make_unique<WorkspaceLibraryDb>(mWsDir);
   }
@@ -87,7 +88,7 @@ public:
 
 TEST_F(KiCadLibraryImportTest, testImport) {
   const FilePath src(TEST_DATA_DIR "/unittests/kicadimport");
-  const FilePath dst = FilePath::getRandomTempPath();
+  const FilePath dst = Application::getRandomTempPath();
 
   KiCadLibraryImport import(*mWsDb, dst);
   std::shared_ptr<MessageLogger> log = std::make_shared<MessageLogger>();


### PR DESCRIPTION
On UNIX systems, use `$XDG_RUNTIME_DIR` for the temporary directory, or as fallback, a user-specific directory within `/tmp`. This avoids permission errors when running LibrePCB from multiple users.

No change on Windows and macOS since their temporary directory were already user-specific.

Fixes #1871 