### PR TITLE
Clarify usage of LLM in contribution guidelines & add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!--
+IMPORTANT: Using this PR template is mandatory, do not delete it.
+TIP:       Don't check the checkboxes in markdown. Just submit the PR, then
+           check the relevant checkboxes by clicking in the rendered preview.
+-->
+
+## Description
+<!-- Describe what the change does and why it is needed. -->
+
+
+
+## Checklist
+<!--
+Check the boxes of things you have done. Leave any other boxes unchecked (do
+not delete them). None of those tasks are mandatory. They are intended as a
+reminder for yourself what *might* make sense to do, and also helps us to
+understand the tasks you already have done.
+-->
+
+- [ ] I am aware of the [contributing guidelines](/CONTRIBUTING.md)
+- [ ] I manually tested the changes extensively and am sure they work perfectly
+  - [ ] I tested on Windows
+  - [ ] I tested on macOS
+  - [ ] I tested on Linux
+- [ ] I am sure the changes do not affect any other features (no regressions)
+
+## Usage of AI/LLM/Agents
+<!-- MANDATORY: Declare how LLMs were used to create this pull request. -->
+
+- [ ] No LLM was used at all to create this PR
+- [ ] For research
+- [ ] For code/tests/documentation
+- [ ] For something else (specify):
+- [ ] I reviewed **all** of the generated content in detail with my human
+      brain and can confirm it has at least the same quality as if I had
+      written it by myself
+
+## Other Notes
+<!-- Anything else we should know about this PR? Open questions? -->
+
+
+
+## Related Issues
+<!-- Write "Fixes #12345" if this PR fixes an issue. -->
+
+
+
+<!-- End of template. Feel free to add more sections if needed. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,36 @@ there are many other ways how to contribute to the LibrePCB project, see
   your idea first!** Also note that we do not accept major changes
   (e.g. changes affecting the file format) at any time, see details in our
   [development workflow documentation](https://developers.librepcb.org/da/dbc/doc_release_workflow.html#doc_release_workflow_branches).
-- Please search issues and pull requests before adding something new to avoid duplicating efforts and conversations.
+- Please search issues and pull requests before adding something new to avoid
+  duplicating efforts and conversations.
 - We use some labels to mark issues as suitable for contributors, check those
   out to find something to work on:
   - [`help wanted`](https://github.com/LibrePCB/LibrePCB/labels/help%20wanted)
   - [`easy`](https://github.com/LibrePCB/LibrePCB/labels/easy)
 - To contact us, use one of the options listed at https://librepcb.org/help/.
+
+## Use of AI/LLM/Agents
+
+I, [@ubruhin](https://github.com/ubruhin), am tired of reading LLM generated
+text or code slop and don't want to waste time with it. Therefore I kindly
+ask you to follow some **important** rules about the use of LLM / agents:
+
+- Do not use LLM for writing pull request descriptions, issues, or comments
+  on those. If I want to chat with an LLM, I will do so on myself. In issues
+  and pull requests, I want to chat with humans.
+- Any usage of LLM has to be declared clearly. No matter if you write a comment
+  referencing "knowledge" you gained through an LLM, or if you used an LLM to
+  write some of the code of a pull request - make it transparent what you have
+  used it for.
+- Any output from an LLM (no matter whether "knowledge" or code) has to be
+  verified **in detail** by yourself. It is not my job to correct what the LLM
+  told you wrong or coded wrong.
+
+To summarize: Use of LLMs is not forbidden when contributing to LibrePCB. Just
+use your brain to make sure no AI slop is ending up in issues or pull requests.
+
+As soon as I suspect the use of an LLM without following those rules, I'll
+stop the discussion and close the pull request or issue.
 
 ## Getting Started
 
@@ -62,9 +86,6 @@ there are many other ways how to contribute to the LibrePCB project, see
 - Run all tests to ensure nothing else was accidentally broken.
   - This is done by running the binary
     `./build/tests/unittests/librepcb-unittests`.
-- If you like, feel free to add yourself to the
-  [AUTHORS.md](https://github.com/LibrePCB/LibrePCB/blob/master/AUTHORS.md)
-  file.
 
 ## Submitting Changes
 


### PR DESCRIPTION
I don't want to forbid usage of LLMs for contributions, but I am tired of chatting with LLMs through GitHub issues/PRs and of AI slop in the diffs. Therefore I specified some rules about the usage of LLMs in the contribution guidelines. In addition, I added a PR template which (beside other things) contains a section to declare the usage of LLMs, as now required by those new rules.

Rendered previews:
- [CONTRIBUTING.md](https://github.com/LibrePCB/LibrePCB/blob/pr-template/CONTRIBUTING.md#use-of-aillmagents)
- [pull_request_template.md](https://github.com/LibrePCB/LibrePCB/blob/pr-template/.github/pull_request_template.md)

Any feedback welcome.