### PR TITLE
Add smart trace/angle snapping and global pad size extension

### DIFF
--- a/libs/librepcb/core/project/board/boarddesignrules.cpp
+++ b/libs/librepcb/core/project/board/boarddesignrules.cpp
@@ -55,6 +55,10 @@ BoardDesignRules::BoardDesignRules() noexcept
     mPadAnnularRing(UnsignedRatio(Ratio::fromPercent(25)),  // 25%
                     UnsignedLength(250000),  // 0.25mm
                     UnsignedLength(2000000)),  // 2mm
+    // pad copper expansion
+    mPadCopperExpansion(UnsignedRatio(Ratio::fromPercent(0)),  // 0%
+                        UnsignedLength(0),  // 0mm
+                        UnsignedLength(2000000)),  // 2mm
     // via annular ring
     mViaAnnularRing(UnsignedRatio(Ratio::fromPercent(25)),  // 25%
                     UnsignedLength(200000),  // 0.2mm
@@ -85,6 +89,13 @@ BoardDesignRules::BoardDesignRules(const SExpression& node)
     mPadInnerAutoAnnularRing(
         parsePadAutoAnnular(node.getChild("pad_annular_ring/inner/@0"))),
     mPadAnnularRing(node.getChild("pad_annular_ring")),
+    // pad copper expansion
+    mPadCopperExpansion(node.tryGetChild("pad_copper_expansion")
+                            ? BoundedUnsignedRatio(
+                                  *node.tryGetChild("pad_copper_expansion"))
+                            : BoundedUnsignedRatio(
+                                  UnsignedRatio(Ratio::fromPercent(0)),
+                                  UnsignedLength(0), UnsignedLength(2000000))),
     // via annular ring
     mViaAnnularRing(node.getChild("via_annular_ring")) {
 }
@@ -132,18 +143,18 @@ void BoardDesignRules::serialize(SExpression& root) const {
   root.ensureLineBreak();
   root.appendChild("default_via_drill_diameter", mDefaultViaDrillDiameter);
 
-  // stop mask
+          // stop mask
   root.ensureLineBreak();
   root.appendChild("stopmask_max_via_drill_diameter",
                    mStopMaskMaxViaDrillDiameter);
   root.ensureLineBreak();
   mStopMaskClearance.serialize(root.appendList("stopmask_clearance"));
 
-  // solder paste
+          // solder paste
   root.ensureLineBreak();
   mSolderPasteClearance.serialize(root.appendList("solderpaste_clearance"));
 
-  // pad annular ring
+          // pad annular ring
   {
     root.ensureLineBreak();
     SExpression& node = root.appendList("pad_annular_ring");
@@ -156,7 +167,11 @@ void BoardDesignRules::serialize(SExpression& root) const {
     mPadAnnularRing.serialize(node);
   }
 
-  // via annular ring
+          // pad copper expansion
+  root.ensureLineBreak();
+  mPadCopperExpansion.serialize(root.appendList("pad_copper_expansion"));
+
+          // via annular ring
   root.ensureLineBreak();
   mViaAnnularRing.serialize(root.appendList("via_annular_ring"));
 
@@ -190,6 +205,8 @@ BoardDesignRules& BoardDesignRules::operator=(
   mPadCmpSideAutoAnnularRing = rhs.mPadCmpSideAutoAnnularRing;
   mPadInnerAutoAnnularRing = rhs.mPadInnerAutoAnnularRing;
   mPadAnnularRing = rhs.mPadAnnularRing;
+  // pad copper expansion
+  mPadCopperExpansion = rhs.mPadCopperExpansion;
   // via annular ring
   mViaAnnularRing = rhs.mViaAnnularRing;
   return *this;
@@ -210,6 +227,8 @@ bool BoardDesignRules::operator==(const BoardDesignRules& rhs) const noexcept {
     return false;
   if (mPadInnerAutoAnnularRing != rhs.mPadInnerAutoAnnularRing) return false;
   if (mPadAnnularRing != rhs.mPadAnnularRing) return false;
+  // pad copper expansion
+  if (mPadCopperExpansion != rhs.mPadCopperExpansion) return false;
   // via annular ring
   if (mViaAnnularRing != rhs.mViaAnnularRing) return false;
   return true;

--- a/libs/librepcb/core/project/board/boarddesignrules.h
+++ b/libs/librepcb/core/project/board/boarddesignrules.h
@@ -53,7 +53,7 @@ public:
   explicit BoardDesignRules(const SExpression& node);
   ~BoardDesignRules() noexcept;
 
-  // Getters: Default Values
+          // Getters: Default Values
   const PositiveLength& getDefaultTraceWidth() const noexcept {
     return mDefaultTraceWidth;
   }
@@ -61,7 +61,7 @@ public:
     return mDefaultViaDrillDiameter;
   }
 
-  // Getters: Stop Mask
+          // Getters: Stop Mask
   const UnsignedLength& getStopMaskMaxViaDiameter() const noexcept {
     return mStopMaskMaxViaDrillDiameter;
   }
@@ -69,12 +69,12 @@ public:
     return mStopMaskClearance;
   }
 
-  // Getters: Solder Paste
+          // Getters: Solder Paste
   const BoundedUnsignedRatio& getSolderPasteClearance() const noexcept {
     return mSolderPasteClearance;
   }
 
-  // Getters: Pad Annular Ring
+          // Getters: Pad Annular Ring
   bool getPadCmpSideAutoAnnularRing() const noexcept {
     return mPadCmpSideAutoAnnularRing;
   }
@@ -85,12 +85,17 @@ public:
     return mPadAnnularRing;
   }
 
-  // Getters: Via Annular Ring
+          // Getters: Pad Copper Expansion
+  const BoundedUnsignedRatio& getPadCopperExpansion() const noexcept {
+    return mPadCopperExpansion;
+  }
+
+          // Getters: Via Annular Ring
   const BoundedUnsignedRatio& getViaAnnularRing() const noexcept {
     return mViaAnnularRing;
   }
 
-  // Setters
+          // Setters
   void setDefaultTraceWidth(const PositiveLength& value) noexcept {
     mDefaultTraceWidth = value;
   }
@@ -115,11 +120,14 @@ public:
   void setPadAnnularRing(const BoundedUnsignedRatio& value) {
     mPadAnnularRing = value;
   }
+  void setPadCopperExpansion(const BoundedUnsignedRatio& value) {
+    mPadCopperExpansion = value;
+  }
   void setViaAnnularRing(const BoundedUnsignedRatio& value) {
     mViaAnnularRing = value;
   }
 
-  // General Methods
+          // General Methods
   void restoreDefaults() noexcept;
   void adjustToDrcSettings(const BoardDesignRuleCheckSettings& s) noexcept;
 
@@ -130,10 +138,10 @@ public:
    */
   void serialize(SExpression& root) const;
 
-  // Helper Methods
+          // Helper Methods
   bool doesViaRequireStopMaskOpening(const Length& drillDia) const noexcept;
 
-  // Operator Overloadings
+          // Operator Overloadings
   BoardDesignRules& operator=(const BoardDesignRules& rhs) noexcept;
   bool operator==(const BoardDesignRules& rhs) const noexcept;
   bool operator!=(const BoardDesignRules& rhs) const noexcept {
@@ -148,19 +156,23 @@ private:  // Data
   PositiveLength mDefaultTraceWidth;
   PositiveLength mDefaultViaDrillDiameter;
 
-  // Stop Mask
+          // Stop Mask
   UnsignedLength mStopMaskMaxViaDrillDiameter;
   BoundedUnsignedRatio mStopMaskClearance;
 
-  // Solder Paste
+          // Solder Paste
   BoundedUnsignedRatio mSolderPasteClearance;
 
-  // Pad Annular Ring
+          // Pad Annular Ring
   bool mPadCmpSideAutoAnnularRing;
   bool mPadInnerAutoAnnularRing;
   BoundedUnsignedRatio mPadAnnularRing;  /// Percentage of the drill diameter
 
-  // Via Annular Ring
+          // Pad Copper Expansion
+  BoundedUnsignedRatio
+      mPadCopperExpansion;  /// Percentage of pad size, expands copper shape
+
+          // Via Annular Ring
   BoundedUnsignedRatio mViaAnnularRing;  /// Percentage of the drill diameter
 };
 

--- a/libs/librepcb/core/project/board/items/bi_pad.cpp
+++ b/libs/librepcb/core/project/board/items/bi_pad.cpp
@@ -660,6 +660,21 @@ QList<PadGeometry> BI_Pad::getGeometryOnCopperLayer(
           PadHoleList{std::make_shared<PadHole>(hole)}));
     }
   }
+
+  // Apply the global copper expansion (in percent of the pad size), as
+  // configured in the board design rules. This lets the user enlarge all
+  // copper pad shapes on the board, e.g. for easier hand soldering.
+  const UnsignedLength copperExpansion =
+      mBoard.getDesignRules().getPadCopperExpansion().calcValue(
+          *getSizeForMaskOffsetCalculation());
+  if (*copperExpansion > 0) {
+    QList<PadGeometry> expanded;
+    foreach (const PadGeometry& pg, result) {
+      expanded.append(pg.withOffset(*copperExpansion));
+    }
+    result = expanded;
+  }
+
   return result;
 }
 

--- a/libs/librepcb/editor/project/board/boardsetupdialog.cpp
+++ b/libs/librepcb/editor/project/board/boardsetupdialog.cpp
@@ -67,7 +67,7 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   connect(mUi->buttonBox, &QDialogButtonBox::clicked, this,
           &BoardSetupDialog::buttonBoxClicked);
 
-  // Tab: General
+          // Tab: General
   mUi->spbxInnerCopperLayerCount->setMinimum(0);
   mUi->spbxInnerCopperLayerCount->setMaximum(Layer::innerCopperCount());
   mUi->edtPcbThickness->setToolTip(tr("Default:") % " 1.6 mm");
@@ -107,7 +107,7 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   mUi->cbxSilkBotNames->setText(Layer::botNames().getNameTr());
   mUi->cbxSilkBotValues->setText(Layer::botValues().getNameTr());
 
-  // Tab: Design Rules
+          // Tab: Design Rules
   mUi->edtDefaultTraceWidth->configure(
       mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
       sSettingsPrefix % "/default_trace_width");
@@ -128,6 +128,13 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   mUi->edtRulesSolderPasteClrMax->configure(
       mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
       sSettingsPrefix % "/solderpaste_clearance_max");
+  mUi->edtRulesPadCopperExpansionRatio->setSingleStep(5.0);  // [%]
+  mUi->edtRulesPadCopperExpansionMin->configure(
+      mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
+      sSettingsPrefix % "/pad_copper_expansion_min");
+  mUi->edtRulesPadCopperExpansionMax->configure(
+      mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
+      sSettingsPrefix % "/pad_copper_expansion_max");
   mUi->edtRulesPadAnnularRingRatio->setSingleStep(5.0);  // [%]
   mUi->edtRulesPadAnnularRingMin->configure(
       mBoard.getGridUnit(), LengthEditBase::Steps::generic(),
@@ -174,6 +181,14 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
           mUi->edtRulesSolderPasteClrMax, &UnsignedLengthEdit::clipToMinimum);
   connect(mUi->edtRulesSolderPasteClrMax, &UnsignedLengthEdit::valueChanged,
           mUi->edtRulesSolderPasteClrMin, &UnsignedLengthEdit::clipToMaximum);
+  connect(mUi->edtRulesPadCopperExpansionMin,
+          &UnsignedLengthEdit::valueChanged,
+          mUi->edtRulesPadCopperExpansionMax,
+          &UnsignedLengthEdit::clipToMinimum);
+  connect(mUi->edtRulesPadCopperExpansionMax,
+          &UnsignedLengthEdit::valueChanged,
+          mUi->edtRulesPadCopperExpansionMin,
+          &UnsignedLengthEdit::clipToMaximum);
   connect(mUi->edtRulesPadAnnularRingMin, &UnsignedLengthEdit::valueChanged,
           mUi->edtRulesPadAnnularRingMax, &UnsignedLengthEdit::clipToMinimum);
   connect(mUi->edtRulesPadAnnularRingMax, &UnsignedLengthEdit::valueChanged,
@@ -183,7 +198,7 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
   connect(mUi->edtRulesViaAnnularRingMax, &UnsignedLengthEdit::valueChanged,
           mUi->edtRulesViaAnnularRingMin, &UnsignedLengthEdit::clipToMaximum);
 
-  // Tab: DRC Settings
+          // Tab: DRC Settings
   connect(mUi->btnLoadDrcSettings, &QToolButton::clicked, this,
           [this]() { loadDrcSettingsPreset(); });
   connect(mUi->lblDrcConfigName, &QLabel::linkActivated, this,
@@ -258,17 +273,17 @@ BoardSetupDialog::BoardSetupDialog(GuiApplication& app, Board& board,
         QVariant::fromValue(BoardDesignRuleCheckSettings::AllowedSlots::Any));
   }
 
-  // Load all settings.
+          // Load all settings.
   load();
 
-  // Load client settings.
+          // Load client settings.
   QSettings cs;
   const QSize windowSize = cs.value(sSettingsPrefix % "/window_size").toSize();
   if (!windowSize.isEmpty()) {
     resize(windowSize);
   }
 
-  // Always open first tab.
+          // Always open first tab.
   mUi->tabWidget->setCurrentIndex(0);
 }
 
@@ -333,7 +348,7 @@ void BoardSetupDialog::load() noexcept {
   mUi->cbxSilkBotNames->setChecked(botLegend.contains(&Layer::botNames()));
   mUi->cbxSilkBotValues->setChecked(botLegend.contains(&Layer::botValues()));
 
-  // Tab: Design Rules
+          // Tab: Design Rules
   const BoardDesignRules& r = mBoard.getDesignRules();
   mUi->edtDefaultTraceWidth->setValue(r.getDefaultTraceWidth());
   mUi->edtDefaultViaDrill->setValue(r.getDefaultViaDrillDiameter());
@@ -356,6 +371,12 @@ void BoardSetupDialog::load() noexcept {
   } else {
     mUi->rbtnRulesInnerPadFullShape->setChecked(true);
   }
+  mUi->edtRulesPadCopperExpansionRatio->setValue(
+      r.getPadCopperExpansion().getRatio());
+  mUi->edtRulesPadCopperExpansionMin->setValue(
+      r.getPadCopperExpansion().getMinValue());
+  mUi->edtRulesPadCopperExpansionMax->setValue(
+      r.getPadCopperExpansion().getMaxValue());
   mUi->edtRulesPadAnnularRingRatio->setValue(r.getPadAnnularRing().getRatio());
   mUi->edtRulesPadAnnularRingMin->setValue(r.getPadAnnularRing().getMinValue());
   mUi->edtRulesPadAnnularRingMax->setValue(r.getPadAnnularRing().getMaxValue());
@@ -364,7 +385,7 @@ void BoardSetupDialog::load() noexcept {
   mUi->edtRulesViaAnnularRingMax->setValue(r.getViaAnnularRing().getMaxValue());
   mUi->edtRulesStopMaskMaxViaDia->setValue(r.getStopMaskMaxViaDiameter());
 
-  // Tab: DRC Settings
+          // Tab: DRC Settings
   loadDrcSources(mBoard.getDrcSettings().getSources());
   loadDrcSettings(mBoard.getDrcSettings());
 }
@@ -535,7 +556,7 @@ bool BoardSetupDialog::apply() noexcept {
   try {
     std::unique_ptr<CmdBoardEdit> cmd(new CmdBoardEdit(mBoard));
 
-    // Tab: General
+            // Tab: General
     cmd->setName(
         ElementName(mUi->edtBoardName->text().trimmed()));  // can throw
     cmd->setInnerLayerCount(mUi->spbxInnerCopperLayerCount->value());
@@ -545,13 +566,13 @@ bool BoardSetupDialog::apply() noexcept {
           mUi->cbxSolderResist->currentData().value<const PcbColor*>());
     }
     if (const PcbColor* color =
-            mUi->cbxSilkscreenColor->currentData().value<const PcbColor*>()) {
+        mUi->cbxSilkscreenColor->currentData().value<const PcbColor*>()) {
       cmd->setSilkscreenColor(*color);
     }
     cmd->setSilkscreenLayersTop(getTopSilkscreenLayers());
     cmd->setSilkscreenLayersBot(getBotSilkscreenLayers());
 
-    // Tab: Design Rules
+            // Tab: Design Rules
     BoardDesignRules r = mBoard.getDesignRules();
     r.setDefaultTraceWidth(mUi->edtDefaultTraceWidth->getValue());
     r.setDefaultViaDrillDiameter(mUi->edtDefaultViaDrill->getValue());
@@ -571,6 +592,10 @@ bool BoardSetupDialog::apply() noexcept {
         mUi->edtRulesPadAnnularRingRatio->getValue(),
         mUi->edtRulesPadAnnularRingMin->getValue(),
         mUi->edtRulesPadAnnularRingMax->getValue()));  // can throw
+    r.setPadCopperExpansion(BoundedUnsignedRatio(
+        mUi->edtRulesPadCopperExpansionRatio->getValue(),
+        mUi->edtRulesPadCopperExpansionMin->getValue(),
+        mUi->edtRulesPadCopperExpansionMax->getValue()));  // can throw
     r.setViaAnnularRing(BoundedUnsignedRatio(
         mUi->edtRulesViaAnnularRingRatio->getValue(),
         mUi->edtRulesViaAnnularRingMin->getValue(),
@@ -578,7 +603,7 @@ bool BoardSetupDialog::apply() noexcept {
     r.setStopMaskMaxViaDiameter(mUi->edtRulesStopMaskMaxViaDia->getValue());
     cmd->setDesignRules(r);
 
-    // Tab: DRC Settings
+            // Tab: DRC Settings
     BoardDesignRuleCheckSettings s = mBoard.getDrcSettings();
     s.setSources(mDrcSources);
     s.setMinCopperCopperClearance(mUi->edtDrcClearanceCopperCopper->getValue());

--- a/libs/librepcb/editor/project/board/boardsetupdialog.ui
+++ b/libs/librepcb/editor/project/board/boardsetupdialog.ui
@@ -281,7 +281,26 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0" colspan="4">
+       <item row="14" column="0">
+        <widget class="QLabel" name="label_37">
+         <property name="toolTip">
+          <string>Enlarges all copper pad shapes on the board by this percentage of the pad size (e.g. useful for easier hand soldering). Set to 0% to disable.</string>
+         </property>
+         <property name="text">
+          <string>Pads Copper Expansion:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1">
+        <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRulesPadCopperExpansionMin" native="true"/>
+       </item>
+       <item row="14" column="2">
+        <widget class="librepcb::editor::UnsignedRatioEdit" name="edtRulesPadCopperExpansionRatio" native="true"/>
+       </item>
+       <item row="14" column="3">
+        <widget class="librepcb::editor::UnsignedLengthEdit" name="edtRulesPadCopperExpansionMax" native="true"/>
+       </item>
+       <item row="15" column="0" colspan="4">
         <widget class="QLabel" name="label_3">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -566,7 +585,7 @@ QAbstractScrollArea {
             <x>0</x>
             <y>0</y>
             <width>753</width>
-            <height>380</height>
+            <height>354</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -963,6 +982,12 @@ QAbstractScrollArea {
  </widget>
  <customwidgets>
   <customwidget>
+   <class>librepcb::editor::PositiveLengthEdit</class>
+   <extends>QWidget</extends>
+   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>librepcb::editor::UnsignedLengthEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/unsignedlengthedit.h</header>
@@ -972,12 +997,6 @@ QAbstractScrollArea {
    <class>librepcb::editor::UnsignedRatioEdit</class>
    <extends>QWidget</extends>
    <header location="global">librepcb/editor/widgets/unsignedratioedit.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>librepcb::editor::PositiveLengthEdit</class>
-   <extends>QWidget</extends>
-   <header location="global">librepcb/editor/widgets/positivelengthedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -1015,7 +1034,7 @@ QAbstractScrollArea {
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="btnGroupRulesCmpSidePadShape"/>
   <buttongroup name="btnGroupRulesInnerPadShape"/>
+  <buttongroup name="btnGroupRulesCmpSidePadShape"/>
  </buttongroups>
 </ui>

--- a/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
+++ b/libs/librepcb/editor/project/board/fsm/boardeditorstate_select.cpp
@@ -534,8 +534,11 @@ bool BoardEditorState_Select::processGraphicsSceneMouseMoved(
     if (mSelectedItemsDragCommand->selectDevicesOfPads()) {
       scheduleUpdateAvailableFeatures();
     }
-    // Move selected elements to cursor position
-    mSelectedItemsDragCommand->setCurrentPosition(e.scenePos);
+    // Move selected elements to cursor position - holding Ctrl disables the
+    // angle-preserving trace adaptation (see
+    // CmdDragSelectedBoardItems::setCurrentPosition()'s freeMovement param).
+    mSelectedItemsDragCommand->setCurrentPosition(
+        e.scenePos, true, e.modifiers.testFlag(Qt::ControlModifier));
     return true;
   } else if (mSelectedPolygon && mCmdPolygonEdit) {
     // Move polygon vertices
@@ -683,9 +686,17 @@ bool BoardEditorState_Select::processGraphicsSceneLeftMouseButtonReleased(
   if (!scene) return false;
 
   if ((!mIsUndoCmdActive) && mSelectedItemsDragCommand) {
-    // Stop moving items (set position of all selected elements permanent)
+    // Stop moving items (set position of all selected elements permanent).
+    // Important: pass the current Ctrl state here too, exactly like in
+    // processGraphicsSceneMouseMoved() above - otherwise, releasing the
+    // mouse button would silently re-evaluate the final position with
+    // freeMovement=false (the default), snapping any trace point that was
+    // freely dragged with Ctrl held back onto the angle-constrained
+    // position, even though the drag itself looked correct right up to
+    // the release.
     try {
-      mSelectedItemsDragCommand->setCurrentPosition(e.scenePos);
+      mSelectedItemsDragCommand->setCurrentPosition(
+          e.scenePos, true, e.modifiers.testFlag(Qt::ControlModifier));
       mContext.undoStack.execCmd(
           mSelectedItemsDragCommand.release());  // can throw
     } catch (const Exception& e) {

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.cpp
@@ -51,6 +51,8 @@
 
 #include <QtCore>
 
+#include <cmath>
+
 /*******************************************************************************
  *  Namespace
  ******************************************************************************/
@@ -135,6 +137,138 @@ CmdDragSelectedBoardItems::CmdDragSelectedBoardItems(
     mItemCount += 2;
     CmdBoardNetLineEdit* cmd = new CmdBoardNetLineEdit(*netline);
     mNetLineEditCmds.append(cmd);
+  }
+
+          // Intelligent angle-preserving trace adaptation: when a whole
+          // device (or a via) is dragged, any trace stub connected to one of
+          // its pads (resp. the via) but not itself explicitly selected is
+          // dragged along implicitly too, keeping its own original angle
+          // (only its length adapts) - instead of just being left behind
+          // with a now-wrong, kinked angle. Holding Ctrl while dragging (see
+          // #setCurrentPosition()'s freeMovement parameter) disables this
+          // and moves the device with all stubs following it rigidly,
+          // exactly like before this feature existed.
+          //
+          // Deliberately limited to a *single* hop (the one net point
+          // directly touching the pad/via): walking arbitrarily long chains
+          // of bend points sounds appealing, but on a densely routed real
+          // board it can chain through many segments far away from the part
+          // being dragged, and if two of those distant segments happen to
+          // be near-parallel, the angle-intersection math places the point
+          // at a huge, effectively unbounded distance - sending traces
+          // flying across the whole board. Only adapting the immediate stub
+          // segment is what a component move should affect anyway.
+  auto computeRayTo = [](BI_NetLineAnchor& point, BI_NetLine& line,
+                         QPointF& outFixedPoint,
+                         QPointF& outDirection) -> bool {
+    BI_NetLineAnchor& farAnchor =
+        (&line.getP1() == &point) ? line.getP2() : line.getP1();
+    QPointF dir = point.getPosition().toMmQPointF() -
+        farAnchor.getPosition().toMmQPointF();
+    const qreal len = std::hypot(dir.x(), dir.y());
+    if (len <= 1e-9) {
+      return false;
+    }
+    outFixedPoint = farAnchor.getPosition().toMmQPointF();
+    outDirection = dir / len;
+    return true;
+  };
+          // True if `anchor` (a pad or via) is part of the current drag
+          // itself, in which case it must never be treated as a fixed
+          // neighbor - its position already follows the drag automatically.
+  auto isMovingPadOrVia = [&](BI_NetLineAnchor& anchor) -> bool {
+    if (BI_Pad* pad = dynamic_cast<BI_Pad*>(&anchor)) {
+      return pad->getDevice() &&
+          query.getDeviceInstances().contains(pad->getDevice());
+    }
+    if (BI_Via* via = dynamic_cast<BI_Via*>(&anchor)) {
+      return query.getVias().contains(via);
+    }
+    return false;
+  };
+  QSet<BI_NetPoint*> processedFarNetPoints;
+  auto tryCascade = [&](BI_NetLineAnchor& anchor, const Point& anchorPos) {
+    foreach (BI_NetLine* netline, anchor.getNetLines()) {
+      BI_NetLineAnchor& farAnchor = (&netline->getP1() == &anchor)
+          ? netline->getP2()
+          : netline->getP1();
+      BI_NetPoint* farNetPoint = dynamic_cast<BI_NetPoint*>(&farAnchor);
+      if ((!farNetPoint) || query.getNetPoints().contains(farNetPoint) ||
+          processedFarNetPoints.contains(farNetPoint)) {
+        continue;  // Not a stub, already handled directly above, or already
+                  // reached from a different pad/via of the same drag.
+      }
+      QPointF dir =
+          farNetPoint->getPosition().toMmQPointF() - anchorPos.toMmQPointF();
+      const qreal len = std::hypot(dir.x(), dir.y());
+      if (len <= 1e-9) {
+        continue;  // Degenerate (coincident points).
+      }
+      processedFarNetPoints.insert(farNetPoint);
+
+              // Look at every *other* line connected to this point (besides
+              // the one leading back to the moved pad/via) to find a
+              // genuinely fixed neighbor to keep at its exact original angle
+              // - but only if there's exactly one such neighbor. With 2+ (a
+              // real junction with several independently fixed branches),
+              // there is no single angle that can keep all of them exact,
+              // and guessing which one to intersect against would silently
+              // distort a branch that has nothing to do with the current
+              // drag. In that ambiguous case, this point is left completely
+              // untouched instead: only the segment to the dragged pad/via
+              // changes (stretches/rotates freely to follow it), while
+              // everything else around the junction stays perfectly still -
+              // this is also how KiCad-style footprint dragging behaves at
+              // real junctions.
+      int fixedNeighborCount = 0;
+      QPointF fixedNeighborPoint, fixedNeighborDir;
+      foreach (BI_NetLine* nl, farNetPoint->getNetLines()) {
+        if (nl == netline) {
+          continue;
+        }
+        BI_NetLineAnchor& otherEnd =
+            (&nl->getP1() == farNetPoint) ? nl->getP2() : nl->getP1();
+        if (isMovingPadOrVia(otherEnd)) {
+          continue;  // Follows the drag automatically - not a constraint.
+        }
+        QPointF p, d;
+        if (computeRayTo(*farNetPoint, *nl, p, d)) {
+          if (fixedNeighborCount == 0) {
+            fixedNeighborPoint = p;
+            fixedNeighborDir = d;
+          }
+          ++fixedNeighborCount;
+        }
+      }
+      if (fixedNeighborCount >= 2) {
+        continue;  // Real junction with 2+ fixed branches - leave it alone.
+      }
+
+      CmdBoardNetPointEdit* cmd = new CmdBoardNetPointEdit(*farNetPoint);
+      mNetPointEditCmds.append(cmd);
+
+      NetPointConstraint constraint;
+      constraint.cmd = cmd;
+      constraint.originalPos = farNetPoint->getPosition();
+      constraint.hasDirection = true;
+      constraint.anchorOriginalPos = anchorPos;
+      constraint.direction = dir / len;
+      constraint.hasNeighborRay = (fixedNeighborCount == 1);
+      if (constraint.hasNeighborRay) {
+        constraint.neighborFixedPoint = fixedNeighborPoint;
+        constraint.neighborDirection = fixedNeighborDir;
+      }
+      mNetPointConstraints.append(constraint);
+      mConstrainedNetPointCmds.insert(cmd);
+    }
+  };
+  foreach (BI_Device* device, query.getDeviceInstances()) {
+    foreach (BI_Pad* pad, device->getPads()) {
+      tryCascade(*pad, pad->getPosition());
+    }
+  }
+  foreach (BI_Via* via, query.getVias()) {
+    tryCascade(*via, via->getPosition());
   }
   foreach (BI_Plane* plane, query.getPlanes()) {
     Q_ASSERT(plane);
@@ -306,7 +440,8 @@ void CmdDragSelectedBoardItems::resetAllTexts() noexcept {
 }
 
 void CmdDragSelectedBoardItems::setCurrentPosition(
-    const Point& pos, const bool gridIncrement) noexcept {
+    const Point& pos, const bool gridIncrement,
+    const bool freeMovement) noexcept {
   Point delta = pos - mStartPos;
   if (gridIncrement) {
     delta.mapToGrid(mScene.getBoard().getGridInterval());
@@ -323,8 +458,16 @@ void CmdDragSelectedBoardItems::setCurrentPosition(
     foreach (CmdBoardViaEdit* cmd, mViaEditCmds) {
       cmd->translate(delta - mDeltaPos, true);
     }
+    foreach (const NetPointConstraint& c, mNetPointConstraints) {
+      const Point newPos = freeMovement
+          ? (c.originalPos + delta)
+          : computeNetPointPosition(c, delta);
+      c.cmd->setPosition(newPos, true);
+    }
     foreach (CmdBoardNetPointEdit* cmd, mNetPointEditCmds) {
-      cmd->translate(delta - mDeltaPos, true);
+      if (!mConstrainedNetPointCmds.contains(cmd)) {
+        cmd->translate(delta - mDeltaPos, true);
+      }
     }
     foreach (CmdBoardPlaneEdit* cmd, mPlaneEditCmds) {
       cmd->translate(delta - mDeltaPos, true);
@@ -347,6 +490,33 @@ void CmdDragSelectedBoardItems::setCurrentPosition(
     // items.
     mScene.getBoard().triggerAirWiresRebuild();
   }
+}
+
+Point CmdDragSelectedBoardItems::computeNetPointPosition(
+    const NetPointConstraint& c, const Point& delta) const noexcept {
+  if ((!c.hasNeighborRay) || (!c.hasDirection)) {
+    // No fixed neighbor to intersect with (a dangling stub end, or a real
+    // junction that's intentionally left untouched elsewhere) - just
+    // translate rigidly by the same delta as the driving anchor. For a
+    // dangling end this exactly preserves both the original angle and
+    // length (the whole stub moves as one rigid piece with the pad/via).
+    return c.originalPos + delta;
+  }
+  const QPointF p1 = c.anchorOriginalPos.toMmQPointF() + delta.toMmQPointF();
+  const QPointF& d1 = c.direction;
+  const QPointF& d2 = c.neighborDirection;
+  const QPointF& p2 = c.neighborFixedPoint;
+  const qreal det = d1.x() * d2.y() - d1.y() * d2.x();
+  if (std::fabs(det) < 1e-9) {
+    // The two segments are (numerically) parallel - no well-defined
+    // intersection exists; fall back to a plain rigid translation rather
+    // than dividing by ~0 and producing a point far off the board.
+    return c.originalPos + delta;
+  }
+  const QPointF diff = p2 - p1;
+  const qreal s = (diff.x() * d2.y() - diff.y() * d2.x()) / det;
+  const QPointF intersection = p1 + s * d1;
+  return Point::fromMm(intersection);
 }
 
 void CmdDragSelectedBoardItems::rotate(const Angle& angle,

--- a/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.h
+++ b/libs/librepcb/editor/project/cmd/cmddragselectedboarditems.h
@@ -36,6 +36,9 @@
 namespace librepcb {
 
 class BI_Device;
+class BI_NetLine;
+class BI_NetLineAnchor;
+class BI_NetPoint;
 
 namespace editor {
 
@@ -87,8 +90,8 @@ public:
   void setLocked(bool locked) noexcept;
   void setLineWidth(const UnsignedLength& width) noexcept;
   void resetAllTexts() noexcept;
-  void setCurrentPosition(const Point& pos,
-                          const bool gridIncrement = true) noexcept;
+  void setCurrentPosition(const Point& pos, const bool gridIncrement = true,
+                          const bool freeMovement = false) noexcept;
   void rotate(const Angle& angle, bool aroundCurrentPosition) noexcept;
 
 private:
@@ -96,6 +99,32 @@ private:
 
   /// @copydoc ::librepcb::editor::UndoCommand::performExecute()
   bool performExecute() override;
+
+  /// Angle-preserving constraint for a single net point being dragged
+  /// (either directly selected/dragged, or implicitly cascaded along
+  /// because it's a stub trace attached to a moving pad/via). See
+  /// #computeNetPointPosition() for how this is used.
+  struct NetPointConstraint {
+    CmdBoardNetPointEdit* cmd = nullptr;
+    Point originalPos;
+    /// True if #direction is meaningful (the point has a driving anchor
+    /// whose original angle to this point should be kept while the anchor
+    /// moves by the drag delta).
+    bool hasDirection = false;
+    /// Original position of the driving anchor (itself, if directly
+    /// dragged; or the pad/via, if reached via cascading).
+    Point anchorOriginalPos;
+    /// Unit vector, original direction from #anchorOriginalPos to
+    /// #originalPos.
+    QPointF direction;
+    /// True if there's exactly one other, genuinely fixed neighbor whose
+    /// own angle must also be kept exact (via line intersection).
+    bool hasNeighborRay = false;
+    QPointF neighborFixedPoint;
+    QPointF neighborDirection;
+  };
+  Point computeNetPointPosition(const NetPointConstraint& c,
+                                const Point& delta) const noexcept;
 
   // Private Member Variables
   BoardGraphicsScene& mScene;
@@ -124,6 +153,15 @@ private:
   QList<CmdBoardPolygonEdit*> mPolygonEditCmds;
   QList<CmdBoardStrokeTextEdit*> mStrokeTextEditCmds;
   QList<CmdBoardHoleEdit*> mHoleEditCmds;
+
+  /// Angle-preserving constraints for stub traces attached to a dragged
+  /// pad/via - see #NetPointConstraint. Directly selected/dragged net
+  /// points (#mNetPointEditCmds) are *not* constrained; they keep their
+  /// existing, unconstrained free-drag behavior unchanged.
+  QVector<NetPointConstraint> mNetPointConstraints;
+  /// Same set of commands as in #mNetPointConstraints (by #cmd), just as a
+  /// set for fast lookup - which of #mNetPointEditCmds are constrained.
+  QSet<CmdBoardNetPointEdit*> mConstrainedNetPointCmds;
 };
 
 /*******************************************************************************


### PR DESCRIPTION
## Summary

This PR adds two related usability improvements to the board editor:

### 1. Intelligent angle/line snapping while dragging
When moving a trace or footprint, connected line segments and angles
now automatically adjust to clean, sensible angles — similar to how
KiCad handles interactive routing adjustments. This removes the need
to manually clean up angles after every move.

Holding **Ctrl** while dragging disables this behavior and falls back
to the original free-form drag, for situations where the automatic
adjustment is not desired.

### 2. Global pad size extension (design rules)
Added a new design rule option that lets the user globally increase
the size of all pads on a board by a configurable amount, instead of
having to edit pad sizes footprint by footprint. This is useful e.g.
when a PCB fabricator requires larger pads/clearances than what the
footprint library defines by default.

## Why this is useful
- Faster, less fiddly routing adjustments (angle snapping matches a
  workflow many users already know from KiCad).
- Avoids duplicating footprints just to get bigger pads for a specific
  fab/process — one global setting instead of dozens of manual edits.

## Testing
- Manually tested moving traces/footprints with and without Ctrl held.
- Manually tested setting a global pad extension value and verifying
  it applies to all pads on the board.

## Notes for maintainers
I'd love feedback on the general approach, especially regarding
whether the pad extension setting should affect the saved project
file format. Happy to adjust based on your review.