### PR TITLE
Fix compilation error when building without OpenCASCADE

### DIFF
--- a/libs/librepcb/core/3d/occmodel.cpp
+++ b/libs/librepcb/core/3d/occmodel.cpp
@@ -545,6 +545,14 @@ bool OccModel::isAvailable() noexcept {
   return (USE_OPENCASCADE != 0);
 }
 
+bool OccModel::hasRgbaSupport() noexcept {
+#if USE_OPENCASCADE
+  return (OCC_VERSION_HEX >= 0x070500);
+#else
+  return false;
+#endif
+}
+
 QString OccModel::getOccVersionString() noexcept {
   QString s = OCC_EDITION_NAME;
 #if USE_OPENCASCADE

--- a/libs/librepcb/core/3d/occmodel.h
+++ b/libs/librepcb/core/3d/occmodel.h
@@ -71,6 +71,7 @@ public:
 
   // Static Methods
   static bool isAvailable() noexcept;
+  static bool hasRgbaSupport() noexcept;
   static QString getOccVersionString() noexcept;
   static void setVerboseOutput(bool verbose) noexcept;
   static std::unique_ptr<OccModel> createAssembly(const QString& name);

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -10,10 +10,17 @@ add_definitions(-DTEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../data")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+# Conditionally-included tests (gated by build options)
+# [Claude AI assisted in authoring this solution]
+set(LIBREPCB_UNITTESTS_OPTIONAL_SOURCES)
+if(USE_OPENCASCADE)
+  list(APPEND LIBREPCB_UNITTESTS_OPTIONAL_SOURCES core/3d/occmodeltest.cpp)
+endif()
+
 # Main executable
 add_executable(
   librepcb_unittests
-  core/3d/occmodeltest.cpp
+  ${LIBREPCB_UNITTESTS_OPTIONAL_SOURCES}
   core/algorithm/airwiresbuildertest.cpp
   core/algorithm/netsegmentsimplifiertest.cpp
   core/applicationtest.cpp

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -10,17 +10,10 @@ add_definitions(-DTEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../data")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-# Conditionally-included tests (gated by build options)
-# [Claude AI assisted in authoring this solution]
-set(LIBREPCB_UNITTESTS_OPTIONAL_SOURCES)
-if(USE_OPENCASCADE)
-  list(APPEND LIBREPCB_UNITTESTS_OPTIONAL_SOURCES core/3d/occmodeltest.cpp)
-endif()
-
 # Main executable
 add_executable(
   librepcb_unittests
-  ${LIBREPCB_UNITTESTS_OPTIONAL_SOURCES}
+  core/3d/occmodeltest.cpp
   core/algorithm/airwiresbuildertest.cpp
   core/algorithm/netsegmentsimplifiertest.cpp
   core/applicationtest.cpp

--- a/tests/unittests/core/3d/occmodeltest.cpp
+++ b/tests/unittests/core/3d/occmodeltest.cpp
@@ -20,7 +20,6 @@
 /*******************************************************************************
  *  Includes
  ******************************************************************************/
-#include <Standard_Version.hxx>
 #include <gtest/gtest.h>
 #include <librepcb/core/3d/occmodel.h>
 #include <librepcb/core/application.h>
@@ -226,11 +225,11 @@ TEST_F(OccModelTest, testTransparency) {
     EXPECT_NEAR(std::get<0>(resultColor), 1.0, 0.01);  // Red
     EXPECT_NEAR(std::get<1>(resultColor), 0.0, 0.01);  // Green
     EXPECT_NEAR(std::get<2>(resultColor), 0.0, 0.01);  // Blue
-#if OCC_VERSION_HEX >= 0x070500
-    EXPECT_NEAR(std::get<3>(resultColor), 0.5, 0.01);  // Alpha
-#else
-    EXPECT_NEAR(std::get<3>(resultColor), 1.0, 0.01);  // Alpha (fallback)
-#endif
+    if (OccModel::hasRgbaSupport()) {
+      EXPECT_NEAR(std::get<3>(resultColor), 0.5, 0.01);  // Alpha
+    } else {
+      EXPECT_NEAR(std::get<3>(resultColor), 1.0, 0.01);  // Alpha (fallback)
+    }
   } else {
     GTEST_SKIP();
   }


### PR DESCRIPTION
<!--
IMPORTANT: Using this PR template is mandatory, do not delete it.
TIP:       Don't check the checkboxes in markdown. Just submit the PR, then
           check the relevant checkboxes by clicking in the rendered preview.
-->

## Description
<!-- Describe what the change does and why it is needed. -->
Unit tests fail to build when `USE_OPENCASCADE=OFF` due to unconditional inclusion of the `occmodeltest.cpp` file (which subsequently tries to `#include` OCC header files, which do not exist in a non-OCC build).  (See issue #1883).

This fix modifies `CMakeLists.txt` to _conditionally_ include the OCC model test file based on the build settings.

## Checklist
<!--
Check the boxes of things you have done. Leave any other boxes unchecked (do
not delete them). None of those tasks are mandatory. They are intended as a
reminder for yourself what *might* make sense to do, and also helps us to
understand the tasks you already have done.
-->

- [x] I am aware of the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I manually tested the changes extensively and am sure they work perfectly
  - [x] I tested on Windows
  - [ ] I tested on macOS
  - [ ] I tested on Linux
- [ ] I am sure the changes do not affect any other features (no regressions)

## Usage of AI/LLM/Agents
<!-- MANDATORY: Declare how LLMs were used to create this pull request. -->
Claude AI was used in the writing of the fix.

- [ ] No LLM was used at all to create this PR
- [ ] For research
- [x] For code/tests/documentation
- [ ] For something else (specify):
- [x] I reviewed **all** of the generated content in detail with my human
      brain and can confirm it has at least the same quality as if I had
      written it by myself

## Other Notes
<!-- Anything else we should know about this PR? Open questions? -->

## Related Issues
<!-- Write "Fixes #12345" if this PR fixes an issue. -->
Fixes #1883


<!-- End of template. Feel free to add more sections if needed. -->
