### PR TITLE
CI: Stop using Homebrew, get dependencies from upstream

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,8 @@ jobs:
       CCACHE_MAXSIZE: '500MB'
       CCACHE_DIR: '/Users/runner/ccache-dir'
       CARGO_HOME: '/Users/runner/cargo-home'
+      UV_URL: ${{ matrix.uv_url }}
+      UV_SHA256: ${{ matrix.uv_sha256 }}
       QT_URL: ${{ matrix.qt_url }}
       QT_SHA256: ${{ matrix.qt_sha256 }}
       QT_ROOT: '/Users/runner/qt'
@@ -32,6 +34,8 @@ jobs:
             runner: macos-14  # Must be an ARM64 CPU: https://github.com/actions/runner-images
             arch: arm64
             deployment_target: '11'
+            uv_url: 'https://github.com/astral-sh/uv/releases/download/0.12.10/uv-aarch64-apple-darwin.tar.gz'
+            uv_sha256: '51c6170e8e3a01cef9f33b94f582b7b81ac65046f55d40afb35f9cff5a68c179'
             # Qt 6.7.3 is the last version that runs on macOS 11.
             qt_url: 'https://download.qt.io/archive/qt/6.7/6.7.3/single/qt-everywhere-src-6.7.3.tar.xz'
             qt_sha256: 'a3f1d257cbb14c6536585ffccf7c203ce7017418e1a0c2ed7c316c20c729c801'
@@ -39,6 +43,8 @@ jobs:
             runner: macos-15-intel  # Must be an x86_64 CPU: https://github.com/actions/runner-images
             arch: x86_64
             deployment_target: '10.14'
+            uv_url: 'https://github.com/astral-sh/uv/releases/download/0.12.10/uv-x86_64-apple-darwin.tar.gz'
+            uv_sha256: '5296d5aa2b9143360405eea866f8ef4d5dc8986b164eb0dc35e8f876a9304d30'
             # Qt 6.5.8 is the last version that runs on macOS 10.14.
             qt_url: 'https://qt.mirror.constant.com/archive/qt/6.5/6.5.8/src/single/qt-everywhere-opensource-src-6.5.8.tar.xz'
             qt_sha256: '4eeb391891b325cd00aed6e42cb4ef966ffeef0877e188c9667a702944760c27'

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -7,56 +7,56 @@ set -euv -o pipefail
 # Docker container with all tools preinstalled.
 if [ "$OS" = "mac" ]
 then
-  # Update homebrow to avoid issues due to outdated package database. But
-  # because even the update sometimes fails, let's ignore any errors with
-  # "|| true" (Apple-style error handling). Maybe this way we get successful
-  # builds even if homebrow failed, which saves a lot of time and nerves.
-  echo "Updating package database..."
-  brew update || true
-
-  # Actually we don't want to waste time with upgrading packages, but sometimes
-  # this needs to be done to get it working (maybe it depends on the phase of
-  # the moon whether this is required or not).
-  echo "Upgrading packages..."
-  brew upgrade || true
+  # Important: Do not install any packages from Homebrew! It has caused a lot
+  # of headaches in the past - life is better without it.
 
   # Install create-dmg
   echo "Installing create-dmg..."
-  brew install --force-bottle create-dmg
+  mkdir -p "$RUNNER_TEMP/create-dmg"
+  curl -L "https://github.com/create-dmg/create-dmg/archive/a2b71d0fda6d0df2a86dc7f67082d4d73e84c59f.tar.gz" \
+    |  tar -xz --strip-components=1 -C "$RUNNER_TEMP/create-dmg"
+  make -j$(nproc) -C "$RUNNER_TEMP/create-dmg" prefix="$HOME/.local" install
 
   # Install dylibbundler
   echo "Installing dylibbundler..."
-  brew install --force-bottle dylibbundler
-
-  # Install Ninja
-  echo "Installing ninja..."
-  brew install --force-bottle ninja
+  mkdir -p "$RUNNER_TEMP/dylibbundler"
+  curl -L "https://github.com/auriamg/macdylibbundler/archive/63105a5571e0e9a83a8f2c37d0b91f2398b2031b.tar.gz" \
+    | tar -xz --strip-components=1 -C "$RUNNER_TEMP/dylibbundler"
+  make -j$(nproc) -C "$RUNNER_TEMP/dylibbundler" PREFIX="$HOME/.local" install
 
   # Install Rust toolchain
   # IMPORTANT: Rust from homebrew contains a stdlib that does not run on older
   # macOS versions, therefore we use rustup to install an official build!
   echo "Installing Rust toolchain..."
-  brew install --force-bottle rustup
   rustup install --profile minimal 1.96.0
   rustup default 1.96.0
-  export PATH="$(brew --prefix rustup)/bin:$PATH"
+  export PATH="$CARGO_HOME/bin:$PATH"
 
   # Install Cargo packages
   cargo install --force cargo-llvm-cov
 
   # Install ccache
   echo "Installing ccache..."
-  brew install --force-bottle ccache
+  mkdir -p "$RUNNER_TEMP/ccache"
+  curl -o "$RUNNER_TEMP/ccache.tar.gz" -L \
+    "https://github.com/ccache/ccache/releases/download/v4.14/ccache-4.14-darwin.tar.gz"
+  shasum -a 256 --check <<< \
+    "353a81ea8680d93387102cfde288ebed381a54272cfdc18224f241add6332b39  $RUNNER_TEMP/ccache.tar.gz"
+  tar -xf "$RUNNER_TEMP/ccache.tar.gz" --strip-components=1 -C "$RUNNER_TEMP/ccache"
+  "$RUNNER_TEMP/ccache/install.sh" --prefix="$HOME/.local"
 
   # Install uv
   echo "Installing uv..."
-  brew install --force-bottle uv
+  curl -o "$RUNNER_TEMP/uv.tar.gz" -L "$UV_URL"
+  shasum -a 256 --check <<< "$UV_SHA256  $RUNNER_TEMP/uv.tar.gz"
+  mkdir -p "$HOME/.local/bin"
+  tar -xf "$RUNNER_TEMP/uv.tar.gz" --strip-components=1 -C "$HOME/.local/bin"
 
   # Fix macdeployqt issue (https://github.com/actions/runner-images/issues/7522)
   echo "Killing XProtect..."
   sudo pkill -9 XProtect >/dev/null || true;
   while pgrep XProtect; do sleep 3; done;
 
-  # Add Qt to PATH
-  export PATH="$QT_ROOT/bin:$PATH"
+  # Add Qt & tools to PATH
+  export PATH="$QT_ROOT/bin:$HOME/.local/bin:$PATH"
 fi


### PR DESCRIPTION
## Description
<!-- Describe what the change does and why it is needed. -->

FINALLY getting completely rid of Homebrew on CI :muscle: It turned out it's easy to install all dependencies from the corresponding upstream projects, which is faster (despite some of them are compiled from sources) and causes less headaches since this is much more reproducible. No problems anymore when Homebrew suddenly deploys some breaking change (e.g. dropping binary packages).

## Checklist
<!--
Check the boxes of things you have done. Leave any other boxes unchecked (do
not delete them). None of those tasks are mandatory. They are intended as a
reminder for yourself what *might* make sense to do, and also helps us to
understand the tasks you already have done.
-->

- [x] I am aware of the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I manually tested the changes extensively and am sure they work perfectly
  - [ ] I tested on Windows
  - [ ] I tested on macOS
  - [ ] I tested on Linux
- [ ] I am sure the changes do not affect any other features (no regressions)
  - Binaries will be tested when preparing the next release

## Usage of AI/LLM/Agents
<!-- MANDATORY: Declare how LLMs were used to create this pull request. -->

- [ ] No LLM was used at all to create this PR
- [ ] For research
- [x] For code/tests/documentation
- [ ] For something else (specify):
- [x] I reviewed **all** of the generated content in detail with my human
      brain and can confirm it has at least the same quality as if I had
      written it by myself

## Other Notes
<!-- Anything else we should know about this PR? Open questions? -->



## Related Issues
<!-- Write "Fixes #12345" if this PR fixes an issue. -->

Fixes current CI failure, caused (one more time) by Homebrew.

<!-- End of template. Feel free to add more sections if needed. -->
